### PR TITLE
Up-to-date Logical Models and Terms

### DIFF
--- a/input/fsh/models/HIVARegistration.fsh
+++ b/input/fsh/models/HIVARegistration.fsh
@@ -73,7 +73,7 @@ Description: "This tab describes the data that are collected during the registra
   * ^code[+] = HIVConcepts#HIV.A.DE4
 * referredBy 0..1 Coding "Referred by" "How the client was referred"
   * ^code[+] = HIVConcepts#HIV.A.DE5
-  * referredBy from HIV.A.DE5
+* referredBy from HIV.A.DE5
 * uniqueIdentifier 1..1 Identifier "Unique identifier" "Unique identifier generated for new clients or a universal ID, if used in the country"
   * ^code[+] = HIVConcepts#HIV.A.DE8
 * nationalId 0..1 Identifier "National ID" "National unique identifier assigned to the client, if used in the country"
@@ -86,7 +86,7 @@ Description: "This tab describes the data that are collected during the registra
   * ^code[+] = HIVConcepts#HIV.A.DE12
 * countryOfBirth 1..1 Coding "Country of birth" "Country where the client was born"
   * ^code[+] = HIVConcepts#HIV.A.DE13
-  * countryOfBirth from HIV.A.DE13
+* countryOfBirth from HIV.A.DE13
 * dateOfBirth 0..1 date "Date of birth" "The client's date of birth (DOB) if known"
   * ^code[+] = HIVConcepts#HIV.A.DE14
 * dateOfBirthUnknown 0..1 boolean "Date of birth unknown" "Is the client's DOB is unknown?"
@@ -97,29 +97,29 @@ Description: "This tab describes the data that are collected during the registra
   * ^code[+] = HIVConcepts#HIV.A.DE17
 * gender 1..1 Coding "Gender" "Gender of the client"
   * ^code[+] = HIVConcepts#HIV.A.DE18
-  * gender from HIV.A.DE18
-* other 0..1 string "Other (specify)" "Additional category (please specify)"
+* gender from HIV.A.DE18
+* otherGender 0..1 string "Other (specify)" "Additional category (please specify)"
   * ^code[+] = HIVConcepts#HIV.A.DE24
 * sex 1..1 Coding "Sex" "Sex of the client assigned at birth"
   * ^code[+] = HIVConcepts#HIV.A.DE25
-  * sex from HIV.A.DE25
+* sex from HIV.A.DE25
 * address 1..1 string "Address" "Client's home address or address which the client is consenting to disclose"
   * ^code[+] = HIVConcepts#HIV.A.DE29
 * maritalStatus 0..1 Coding "Marital Status" "Client's current marital status "
   * ^code[+] = HIVConcepts#HIV.A.DE30
-  * maritalStatus from HIV.A.DE30
+* maritalStatus from HIV.A.DE30
 * telephoneNumber 1..1 integer "Telephone number" "Client's telephone number (a landline or a mobile phone number)"
   * ^code[+] = HIVConcepts#HIV.A.DE42
 * administrativeArea 1..1 Coding "Administrative Area" "This should be a context-specific list of administrative areas, such as villages, districts, etc. The purpose of this data element is to allow for grouping and flagging of client data to a particular facility's catchment area. This can be input into the system by the end user OR it can be automated in the database based on the end user's attributes."
   * ^code[+] = HIVConcepts#HIV.A.DE43
-  * administrativeArea from HIV.A.DE43
+* administrativeArea from HIV.A.DE43
 * communicationConsent 0..1 boolean "Communication consent" "Indication that client gave consent to be contacted"
   * ^code[+] = HIVConcepts#HIV.A.DE44
 * reminderMessages 0..1 boolean "Reminder messages" "Whether client wants to receive text or other messages as follow-up for HIV services"
   * ^code[+] = HIVConcepts#HIV.A.DE45
-* communicationPreference 0..* Coding "Communication preference(s)" "How the client would like to receive family planning communications"
+* communicationPreferences 0..* Coding "Communication preference(s)" "How the client would like to receive family planning communications"
   * ^code[+] = HIVConcepts#HIV.A.DE46
-  * communicationPreference from HIV.A.DE46
+* communicationPreferences from HIV.A.DE46
 * clientEmail 0..1 string "Client's email" "Client's primary email account where the client can be contacted"
   * ^code[+] = HIVConcepts#HIV.A.DE49
 * alternateContactName 0..1 string "Alternate contact's name" "Name of an alternate contact, which could be next of kin (e.g. partner, husband, mother, sibling, etc.). The alternate contact would be used in the case of an emergency situation."

--- a/input/fsh/models/HIVBHTSvisit.fsh
+++ b/input/fsh/models/HIVBHTSvisit.fsh
@@ -50,52 +50,52 @@ Description: "This tab describes the data that are collected during the HIV Test
 
 * reasonForVisit 1..* Coding "Reason for visit" "Reason for HIV testing services visit"
   * ^code[+] = HIVConcepts#HIV.B.DE1
-  * reasonForVisit from HIV.B.DE1
+* reasonForVisit from HIV.B.DE1
 * referredThroughPartnerServices 1..* Coding "Referred through partner services" "Client reported coming to the facility after receiving a provider-assisted referral or patient referral from a contact or partner"
   * ^code[+] = HIVConcepts#HIV.B.DE5
-  * referredThroughPartnerServices from HIV.B.DE5
+* referredThroughPartnerServices from HIV.B.DE5
 * typeOfContactOrPartnerForPartnerServices 0..* Coding "Type of contact or partner for partner services" "Client's relationship to the person that referred the client for partner services or family services"
   * ^code[+] = HIVConcepts#HIV.B.DE8
-  * typeOfContactOrPartnerForPartnerServices from HIV.B.DE8
-* contactWithAnduspecteexposureToHiv 1..1 boolean "Contact with and (suspected) exposure to HIV" "When the client is reported to have had suspected exposure to HIV"
+* typeOfContactOrPartnerForPartnerServices from HIV.B.DE8
+* contactWithAndSuspectedExposureToHiv 1..1 boolean "Contact with and (suspected) exposure to HIV" "When the client is reported to have had suspected exposure to HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE13
 * dateTimeOfSuspectedExposureToHiv 0..1 dateTime "Date/time of suspected exposure to HIV" "Date and time when the client had suspected exposure to HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE14
 * testingEntryPoint 1..1 Coding "Testing entry point" "Whether testing is happening in the community or at a facility"
   * ^code[+] = HIVConcepts#HIV.B.DE15
-  * testingEntryPoint from HIV.B.DE15
+* testingEntryPoint from HIV.B.DE15
 * entryPointForCommunityLevelTesting 0..1 Coding "Entry point for community-level testing" "Specific point in the community where testing is happening"
   * ^code[+] = HIVConcepts#HIV.B.DE18
-  * entryPointForCommunityLevelTesting from HIV.B.DE18
+* entryPointForCommunityLevelTesting from HIV.B.DE18
 * entryPointForFacilityLevelTesting 0..1 Coding "Entry point for facility-level testing" "Specific point where testing is happening at a facility"
   * ^code[+] = HIVConcepts#HIV.B.DE22
-  * entryPointForFacilityLevelTesting from HIV.B.DE22
+* entryPointForFacilityLevelTesting from HIV.B.DE22
 * currentlyPregnant 0..1 boolean "Currently pregnant" "Client is currently pregnant"
   * ^code[+] = HIVConcepts#HIV.B.DE29
 * gestationalAge 0..1 integer "Gestational age" "Gestational age in weeks and/or days depending on the source of gestational age"
   * ^code[+] = HIVConcepts#HIV.B.DE30
-* expectedDateOfDelivery 0..1 date "Expected date of delivery (EDD)" "Expected date of delivery based on gestational age"
+* expectedDateOfDeliveryEdd 0..1 date "Expected date of delivery (EDD)" "Expected date of delivery based on gestational age"
   * ^code[+] = HIVConcepts#HIV.B.DE31
 * breastfeeding 0..1 boolean "Breastfeeding" "Infant is being breastfed by mother"
   * ^code[+] = HIVConcepts#HIV.B.DE32
-* partnerHivStatus 0..1 Coding "Partner HIV status (reported)" "The HIV status of the client's partner."
+* partnerHivStatusReported 0..1 Coding "Partner HIV status (reported)" "The HIV status of the client's partner."
   * ^code[+] = HIVConcepts#HIV.B.DE33
-  * partnerHivStatus from HIV.B.DE33
+* partnerHivStatusReported from HIV.B.DE33
 * partnerIsFromAKeyPopulation 0..* Coding "Partner is from a key population" "Client's partner is a member of a key population, that has an increased risk of HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE37
-  * partnerIsFromAKeyPopulation from HIV.B.DE37
-* hasUsedAnHivSelfTestBefore 0..1 boolean "Has used an HIV self-test before (reported)" "The client reported having used an HIV self-test before"
+* partnerIsFromAKeyPopulation from HIV.B.DE37
+* hasUsedAnHivSelfTestBeforeReported 0..1 boolean "Has used an HIV self-test before (reported)" "The client reported having used an HIV self-test before"
   * ^code[+] = HIVConcepts#HIV.B.DE43
 * hivSelfTestResult 0..1 Coding "HIV self-test result" "Results from the reported HIV self-test"
   * ^code[+] = HIVConcepts#HIV.B.DE44
-  * hivSelfTestResult from HIV.B.DE44
+* hivSelfTestResult from HIV.B.DE44
 * dateOfHivSelfTest 0..1 date "Date of HIV self-test" "Date when the HIV self-test was conducted"
   * ^code[+] = HIVConcepts#HIV.B.DE48
 * keyPopulationMember 0..1 boolean "Key population member" "Client is a member of a key population that has an increased risk of HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE49
 * keyPopulationMemberType 0..* Coding "Key population member type" "The type of key population that the client is included in"
   * ^code[+] = HIVConcepts#HIV.B.DE50
-  * keyPopulationMemberType from HIV.B.DE50
+* keyPopulationMemberType from HIV.B.DE50
 * adolescentGirl 0..1 boolean "Adolescent girl" "Calculated field based on age and gender, if client is 10 years or older and under 20 years old"
   * ^code[+] = HIVConcepts#HIV.B.DE56
 * youngWoman 0..1 boolean "Young woman" "Calculated field based on age and gender, if client is 20 years or older and under 25 years old"
@@ -108,17 +108,17 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE60
 * hivExposureType 0..* Coding "HIV exposure type" "Ways in which the client was exposed to HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE61
-  * hivExposureType from HIV.B.DE61
+* hivExposureType from HIV.B.DE61
 * dateInformedOfHivPositiveDiagnosis 0..1 date "Date informed of HIV-positive diagnosis" "The date on which the client was diagnosed with HIV"
   * ^code[+] = HIVConcepts#HIV.B.DE65
 * hivDiagnosingFacility 1..1 Coding "HIV diagnosing facility" "The facility where the client received an HIV-positive diagnosis"
   * ^code[+] = HIVConcepts#HIV.B.DE66
-  * hivDiagnosingFacility from HIV.B.DE66
+* hivDiagnosingFacility from HIV.B.DE66
 * dateOfFirstPositiveTestIndicativeOfHivDiagnosis 0..1 date "Date of first positive test indicative of HIV diagnosis" "Earliest date of HIV diagnosis determined according to the national HIV testing algorithm"
   * ^code[+] = HIVConcepts#HIV.B.DE67
 * hivSerotype 0..1 Coding "HIV serotype" "The client's HIV serotype"
   * ^code[+] = HIVConcepts#HIV.B.DE68
-  * hivSerotype from HIV.B.DE68
+* hivSerotype from HIV.B.DE68
 * hivDiagnosisDate 0..1 date "HIV diagnosis date" "Date diagnosis was returned to client"
   * ^code[+] = HIVConcepts#HIV.B.DE71
 * artStartDate 0..1 date "ART start date" "The date on which the client started or restarted antiretroviral therapy (ART)"
@@ -127,47 +127,47 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE73
 * typeOfContactElicited 0..* Coding "Type of contact elicited" "Client's relationship to the contact identified for voluntary partner services or family services"
   * ^code[+] = HIVConcepts#HIV.B.DE74
-  * typeOfContactElicited from HIV.B.DE74
+* typeOfContactElicited from HIV.B.DE74
 * hivTestOrdered 0..1 boolean "HIV test ordered" "An HIV test of the client was ordered by the provider"
   * ^code[+] = HIVConcepts#HIV.B.DE79
 * hivTestConducted 0..1 boolean "HIV test conducted" "An HIV test was performed on the client during the visit"
   * ^code[+] = HIVConcepts#HIV.B.DE80
 * hivTestType 0..1 Coding "HIV test type" "Type of HIV test"
   * ^code[+] = HIVConcepts#HIV.B.DE81
-  * hivTestType from HIV.B.DE81
+* hivTestType from HIV.B.DE81
 * dateHivTestSent 0..1 dateTime "Date HIV test sent" "Date HIV specimen was sent to lab"
   * ^code[+] = HIVConcepts#HIV.B.DE87
 * assayNumberInTestingStrategy 0..1 Coding "Assay number in testing strategy" "The number of the assay (test kit) in the HIV testing strategy"
   * ^code[+] = HIVConcepts#HIV.B.DE88
-  * assayNumberInTestingStrategy from HIV.B.DE88
-* testResultOfHivAssay_1 0..1 Coding "Test result of HIV assay 1" "The result of the first HIV assay in the testing strategy"
+* assayNumberInTestingStrategy from HIV.B.DE88
+* testResultOfHivAssay1 0..1 Coding "Test result of HIV assay 1" "The result of the first HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.B.DE94
-  * testResultOfHivAssay_1 from HIV.B.DE94
-* testResultOfHivAssay_2 0..1 Coding "Test result of HIV assay 2" "The result of the second HIV assay in the testing strategy"
+* testResultOfHivAssay1 from HIV.B.DE94
+* testResultOfHivAssay2 0..1 Coding "Test result of HIV assay 2" "The result of the second HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.B.DE98
-  * testResultOfHivAssay_2 from HIV.B.DE98
-* testResultOfHivAssay_3 0..1 Coding "Test result of HIV assay 3" "The result of the third HIV assay in the testing strategy"
+* testResultOfHivAssay2 from HIV.B.DE98
+* testResultOfHivAssay3 0..1 Coding "Test result of HIV assay 3" "The result of the third HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.B.DE102
-  * testResultOfHivAssay_3 from HIV.B.DE102
-* testResultOfHivAssay_1Repeated 0..1 Coding "Test result of HIV assay 1 repeated" "The result of the repeated first HIV assay in the testing strategy"
+* testResultOfHivAssay3 from HIV.B.DE102
+* testResultOfHivAssay1Repeated 0..1 Coding "Test result of HIV assay 1 repeated" "The result of the repeated first HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.B.DE106
-  * testResultOfHivAssay_1Repeated from HIV.B.DE106
+* testResultOfHivAssay1Repeated from HIV.B.DE106
 * hivTestDate 0..1 date "HIV test date" "Date of the HIV test"
   * ^code[+] = HIVConcepts#HIV.B.DE110
 * hivTestResult 0..1 Coding "HIV test result" "The result from HIV testing after applying the testing algorithm"
   * ^code[+] = HIVConcepts#HIV.B.DE111
-  * hivTestResult from HIV.B.DE111
+* hivTestResult from HIV.B.DE111
 * hivStatus 1..1 Coding "HIV status" "HIV status reported after applying the national HIV testing algorithm. No single HIV test can provide an HIV-positive diagnosis."
   * ^code[+] = HIVConcepts#HIV.B.DE115
-  * hivStatus from HIV.B.DE115
+* hivStatus from HIV.B.DE115
 * datePositiveHivTestConfirmed 0..1 date "Date positive HIV test confirmed" "Date patient received positive HIV test confirmation (with written documentation)"
   * ^code[+] = HIVConcepts#HIV.B.DE119
 * siteWherePositiveHivTestConfirmed 0..1 Coding "Site where positive HIV test confirmed" "Name or identifier of health facility where HIV test was confirmed"
   * ^code[+] = HIVConcepts#HIV.B.DE120
-  * siteWherePositiveHivTestConfirmed from HIV.B.DE120
+* siteWherePositiveHivTestConfirmed from HIV.B.DE120
 * probableRouteOfTransmission 0..* Coding "Probable route of transmission" "Probable route(s) of transmission of HIV to client"
   * ^code[+] = HIVConcepts#HIV.B.DE121
-  * probableRouteOfTransmission from HIV.B.DE121
+* probableRouteOfTransmission from HIV.B.DE121
 * partnerHivTestConducted 0..1 boolean "Partner HIV test conducted" "If the client does not know the HIV status of the client's partner(s), offer to test and add results here"
   * ^code[+] = HIVConcepts#HIV.B.DE129
 * partnerHivTestOrdered 0..1 boolean "Partner HIV test ordered" "An HIV test for the client's partner has been ordered"
@@ -176,39 +176,39 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE131
 * partnerHivTestResult 0..1 Coding "Partner HIV test result" "The HIV test result of the client's partner"
   * ^code[+] = HIVConcepts#HIV.B.DE132
-  * partnerHivTestResult from HIV.B.DE132
-* partnerHivStatus 0..1 Coding "Partner HIV status (confirmed)" "The HIV status of a sexual or drug-injecting partner of the client, based on a confirmed test result"
+* partnerHivTestResult from HIV.B.DE132
+* partnerHivStatusConfirmed 0..1 Coding "Partner HIV status (confirmed)" "The HIV status of a sexual or drug-injecting partner of the client, based on a confirmed test result"
   * ^code[+] = HIVConcepts#HIV.B.DE136
-  * partnerHivStatus from HIV.B.DE136
+* partnerHivStatusConfirmed from HIV.B.DE136
 * partnerOnArt 0..1 boolean "Partner on ART" "Partner of the client is on ART"
   * ^code[+] = HIVConcepts#HIV.B.DE140
 * partnerVirallySuppressedOnArt 0..1 boolean "Partner virally suppressed on ART" "ART and virally suppression status of a partner of the client"
   * ^code[+] = HIVConcepts#HIV.B.DE141
 * counsellingProvided 1..* Coding "Counselling provided" "Whether counselling was provided to a client during the visit"
   * ^code[+] = HIVConcepts#HIV.B.DE142
-  * counsellingProvided from HIV.B.DE142
+* counsellingProvided from HIV.B.DE142
 * preventionServicesOfferedAndReferrals 1..* Coding "Prevention services offered and referrals" "Offer or refer to prevention services"
   * ^code[+] = HIVConcepts#HIV.B.DE149
-  * preventionServicesOfferedAndReferrals from HIV.B.DE149
+* preventionServicesOfferedAndReferrals from HIV.B.DE149
 * sexualAndReproductiveHealthIntegratedServices 1..* Coding "Sexual and reproductive health integrated services" "Offer or refer to sexual and reproductive health services"
   * ^code[+] = HIVConcepts#HIV.B.DE158
-  * sexualAndReproductiveHealthIntegratedServices from HIV.B.DE158
+* sexualAndReproductiveHealthIntegratedServices from HIV.B.DE158
 * offerOtherClinicalServices 0..* Coding "Offer other clinical services" "Other clinical services offered or referrals given to the client"
   * ^code[+] = HIVConcepts#HIV.B.DE165
-  * offerOtherClinicalServices from HIV.B.DE165
+* offerOtherClinicalServices from HIV.B.DE165
 * otherSupportServices 0..* Coding "Other support services" "Offer or refer for other support services"
   * ^code[+] = HIVConcepts#HIV.B.DE172
-  * otherSupportServices from HIV.B.DE172
-* clinicalEnquiryForIntimatePartnerViolencepdone 0..1 boolean "Clinical enquiry for intimate partner violence (IPV) done" "Whether a clinical enquiry for intimate partner violence was conducted"
+* otherSupportServices from HIV.B.DE172
+* clinicalEnquiryForIntimatePartnerViolenceIpvDone 0..1 boolean "Clinical enquiry for intimate partner violence (IPV) done" "Whether a clinical enquiry for intimate partner violence was conducted"
   * ^code[+] = HIVConcepts#HIV.B.DE178
 * intimatePartnerViolenceEnquiryResults 0..1 Coding "Intimate partner violence enquiry results" "Result of medical inquiry for intimate partner violence"
   * ^code[+] = HIVConcepts#HIV.B.DE179
-  * intimatePartnerViolenceEnquiryResults from HIV.B.DE179
-* otherIpvResult 0..1 string "Other IPV result (specify)" "Other intimate partner violence (IPV) result not described above (specify)"
+* intimatePartnerViolenceEnquiryResults from HIV.B.DE179
+* otherIpvResultSpecify 0..1 string "Other IPV result (specify)" "Other intimate partner violence (IPV) result not described above (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE184
 * offeredVoluntaryPartnerServices 0..1 boolean "Offered voluntary partner services" "Whether the client was offered voluntary partner services or family services"
   * ^code[+] = HIVConcepts#HIV.B.DE185
-* countOfContactsOrPartnersGivenForSocialNetworkBasedPartnerServices 0..1 integer "Count of contacts or partners given for social network-based/partner services" "The quantity of contacts or partners given by a client that accepts social network-based/partner services for follow-up"
+* countOfContactsOrPartnersGivenForSocialNetworkBasedPartner 0..1 integer "Count of contacts or partners given for social network-based/partner services" "The quantity of contacts or partners given by a client that accepts social network-based/partner services for follow-up"
   * ^code[+] = HIVConcepts#HIV.B.DE186
 * offeredSocialNetworkBasedPartnerServices 0..1 boolean "Offered social network-based/partner services" "Whether the client was offered social network-based partner services"
   * ^code[+] = HIVConcepts#HIV.B.DE187
@@ -220,8 +220,8 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE190
 * typeOfFollowUpAppointment 0..* Coding "Type of follow-up appointment" "Type of follow-up appointment for testing services"
   * ^code[+] = HIVConcepts#HIV.B.DE191
-  * typeOfFollowUpAppointment from HIV.B.DE191
-* otherReasonForTheFollowUpAppointment 0..1 string "Other reason for the follow-up appointment (specify)" "Other reason for the follow-up appointment (specify)"
+* typeOfFollowUpAppointment from HIV.B.DE191
+* otherReasonForTheFollowUpAppointmentSpecify 0..1 string "Other reason for the follow-up appointment (specify)" "Other reason for the follow-up appointment (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE194
 * dateTimeOfFollowUpAppointment 0..1 dateTime "Date/time of follow-up appointment" "Date the patient is to return for monitoring, re-supply or any other reason"
   * ^code[+] = HIVConcepts#HIV.B.DE195
@@ -237,14 +237,14 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE200
 * adverseEventSeverity 0..1 Coding "Adverse event severity" "Severity of the adverse event associated with voluntary medical male circumcision (VMMC) procedure"
   * ^code[+] = HIVConcepts#HIV.B.DE201
-  * adverseEventSeverity from HIV.B.DE201
+* adverseEventSeverity from HIV.B.DE201
 * timingOfAdverseEvent 0..1 Coding "Timing of adverse event" "When the adverse event associated with VMMC procedure occurred"
   * ^code[+] = HIVConcepts#HIV.B.DE204
-  * timingOfAdverseEvent from HIV.B.DE204
+* timingOfAdverseEvent from HIV.B.DE204
 * typeOfAdverseVmmcEvent 0..* Coding "Type of adverse VMMC event" "Type of adverse event associated with voluntary medical male circumcision (VMMC) procedure"
   * ^code[+] = HIVConcepts#HIV.B.DE207
-  * typeOfAdverseVmmcEvent from HIV.B.DE207
-* other 0..1 string "Other (specify)" "Client experienced other adverse VMMC event (specify)"
+* typeOfAdverseVmmcEvent from HIV.B.DE207
+* otherTypeOfAdverseVmmcEvent 0..1 string "Other (specify)" "Client experienced other adverse VMMC event (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE223
 * hivRetestPriorToStartingArtConducted 0..1 boolean "HIV retest prior to starting ART conducted" "HIV retest prior to starting ART conducted"
   * ^code[+] = HIVConcepts#HIV.B.DE224
@@ -252,8 +252,8 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE225
 * syndromeStiDiagnosed 0..* Coding "Syndrome/STI diagnosed" "Syndrome or STI for which client is diagnosed"
   * ^code[+] = HIVConcepts#HIV.B.DE226
-  * syndromeStiDiagnosed from HIV.B.DE226
-* other 0..1 string "Other (specify)" "Other syndrome/STI diagnosed (specify)"
+* syndromeStiDiagnosed from HIV.B.DE226
+* otherSyndromeStiDiagnosed 0..1 string "Other (specify)" "Other syndrome/STI diagnosed (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE234
 * anyStiSyndromeDiagnosed 0..1 boolean "Any STI syndrome diagnosed" "Was the client diagnosed with any of the five STI syndromes during this visit?"
   * ^code[+] = HIVConcepts#HIV.B.DE235
@@ -261,84 +261,84 @@ Description: "This tab describes the data that are collected during the HIV Test
   * ^code[+] = HIVConcepts#HIV.B.DE236
 * stiTestedFor 0..* Coding "STI tested for" "STI for which the client was tested"
   * ^code[+] = HIVConcepts#HIV.B.DE237
-  * stiTestedFor from HIV.B.DE237
-* other 0..1 string "Other (specify)" "Client tested for other STI (specify)"
+* stiTestedFor from HIV.B.DE237
+* otherStiTestedFor 0..1 string "Other (specify)" "Client tested for other STI (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE248
 * syphilisTestDate 0..1 dateTime "Syphilis test date" "Date of syphilis test"
   * ^code[+] = HIVConcepts#HIV.B.DE249
 * syphilisTestResult 0..1 Coding "Syphilis test result" "Result from syphilis test"
   * ^code[+] = HIVConcepts#HIV.B.DE250
-  * syphilisTestResult from HIV.B.DE250
+* syphilisTestResult from HIV.B.DE250
 * syphilisTreatmentStartDate 0..1 dateTime "Syphilis treatment start date" "Date of initiation of syphilis treatment"
   * ^code[+] = HIVConcepts#HIV.B.DE254
 * gonorrhoeaTestDate 0..1 dateTime "Gonorrhoea test date" "Date of Gonorrhoea test"
   * ^code[+] = HIVConcepts#HIV.B.DE255
 * gonorrhoeaTestResult 0..1 Coding "Gonorrhoea test result" "Result from Gonorrhoea test"
   * ^code[+] = HIVConcepts#HIV.B.DE256
-  * gonorrhoeaTestResult from HIV.B.DE256
+* gonorrhoeaTestResult from HIV.B.DE256
 * gonorrhoeaTreatmentStartDate 0..1 dateTime "Gonorrhoea treatment start date" "Date of initiation of Gonorrhoea treatment"
   * ^code[+] = HIVConcepts#HIV.B.DE260
 * typeOfSpecimen 0..* Coding "Type of specimen" "Type of specimen to be collected"
   * ^code[+] = HIVConcepts#HIV.B.DE261
-  * typeOfSpecimen from HIV.B.DE261
-* otherTypeOfSpecimen 0..1 string "Other type of specimen (specify)" "Other specimen type to be collected (specify)"
+* typeOfSpecimen from HIV.B.DE261
+* otherTypeOfSpecimenSpecify 0..1 string "Other type of specimen (specify)" "Other specimen type to be collected (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE268
 * syphilisTestType 0..* Coding "Syphilis test type" "Type of diagnostic test used for syphilis (treponema pallidum)"
   * ^code[+] = HIVConcepts#HIV.B.DE269
-  * syphilisTestType from HIV.B.DE269
-* otherSyphilisTestType 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
+* syphilisTestType from HIV.B.DE269
+* otherSyphilisTestTypeSpecify 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE275
 * neisseriaGonorrhoeaeTestType 0..1 Coding "Neisseria gonorrhoeae test type" "Type of diagnostic test used for Neisseria gonorrhoeae"
   * ^code[+] = HIVConcepts#HIV.B.DE276
-  * neisseriaGonorrhoeaeTestType from HIV.B.DE276
-* other 0..1 string "Other (specify)" "Other type of test used (specify)"
+* neisseriaGonorrhoeaeTestType from HIV.B.DE276
+* otherNeisseriaGonorrhoeaeTestType 0..1 string "Other (specify)" "Other type of test used (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE282
-* pocTestForNeisseriaGonorrhoeae 0..1 string "POC Test for Neisseria gonorrhoeae (specify)" "Point-of-care (POC) test used for Neisseria gonorrhoeae (specify)"
+* pocTestForNeisseriaGonorrhoeaeSpecify 0..1 string "POC Test for Neisseria gonorrhoeae (specify)" "Point-of-care (POC) test used for Neisseria gonorrhoeae (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE283
 * chlamydiaTrachomatisTestType 0..1 Coding "Chlamydia trachomatis test type" "Type of diagnostic test used for Chlamydia trachomatis"
   * ^code[+] = HIVConcepts#HIV.B.DE284
-  * chlamydiaTrachomatisTestType from HIV.B.DE284
-* otherTestForChlamydia 0..1 string "Other test for Chlamydia (specify)" "Other type of test used for Chlaymdia (specify)"
+* chlamydiaTrachomatisTestType from HIV.B.DE284
+* otherTestForChlamydiaSpecify 0..1 string "Other test for Chlamydia (specify)" "Other type of test used for Chlaymdia (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE291
-* pocTestTypeForChlamydiaTest 0..1 string "POC Test type for Chlamydia test (specify)" "Point-of-care (POC) test used for Chlamydia (specify)"
+* pocTestTypeForChlamydiaTestSpecify 0..1 string "POC Test type for Chlamydia test (specify)" "Point-of-care (POC) test used for Chlamydia (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE292
 * trichomonasVaginalisTestType 0..1 Coding "Trichomonas vaginalis test type" "Type of diagnostic test used for Trichomonas vaginalis"
   * ^code[+] = HIVConcepts#HIV.B.DE293
-  * trichomonasVaginalisTestType from HIV.B.DE293
-* other 0..1 string "Other (specify)" "Other type of test used (specify)"
+* trichomonasVaginalisTestType from HIV.B.DE293
+* otherTrichomonasVaginalisTestType 0..1 string "Other (specify)" "Other type of test used (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE299
-* pocTestTypeForTrichomonasVaginalisTest 0..1 string "POC Test type for Trichomonas vaginalis test (specify)" "Point-of-care (POC) test used (specify)"
+* pocTestTypeForTrichomonasVaginalisTestSpecify 0..1 string "POC Test type for Trichomonas vaginalis test (specify)" "Point-of-care (POC) test used (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE300
-* herpesSimplexVirusstestType 0..1 Coding "Herpes simplex virus (HSV) test type" "Type of diagnostic test used for herpes simplex virus (HSV)"
+* herpesSimplexVirusHsvTestType 0..1 Coding "Herpes simplex virus (HSV) test type" "Type of diagnostic test used for herpes simplex virus (HSV)"
   * ^code[+] = HIVConcepts#HIV.B.DE301
-  * herpesSimplexVirusstestType from HIV.B.DE301
-* other 0..1 string "Other (specify)" "Other type of test used for Herpes simplex virus (HSV) test (specify)"
+* herpesSimplexVirusHsvTestType from HIV.B.DE301
+* otherHerpesSimplexVirusHsvTestType 0..1 string "Other (specify)" "Other type of test used for Herpes simplex virus (HSV) test (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE305
 * mycoplasmaGenitaliumTestType 0..1 Coding "Mycoplasma genitalium test type" "Type of diagnostic test used for Mycoplasma genitalium"
   * ^code[+] = HIVConcepts#HIV.B.DE306
-  * mycoplasmaGenitaliumTestType from HIV.B.DE306
-* other 0..1 string "Other (specify)" "Other type of test used for Mycoplasma genitalium test (specify)"
+* mycoplasmaGenitaliumTestType from HIV.B.DE306
+* otherMycoplasmaGenitaliumTestType 0..1 string "Other (specify)" "Other type of test used for Mycoplasma genitalium test (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE310
-* testTypeForOtherStiTestedFor 0..1 string "Test type for other STI tested for (specify)" "Test type used for the other specified STI"
+* testTypeForOtherStiTestedForSpecify 0..1 string "Test type for other STI tested for (specify)" "Test type used for the other specified STI"
   * ^code[+] = HIVConcepts#HIV.B.DE311
 * stiTestResult 0..1 Coding "STI test result" "Result from STI test"
   * ^code[+] = HIVConcepts#HIV.B.DE312
-  * stiTestResult from HIV.B.DE312
+* stiTestResult from HIV.B.DE312
 * dateOfStiConfirmatoryTest 0..1 dateTime "Date of STI confirmatory test" "Date of STI confirmatory test"
   * ^code[+] = HIVConcepts#HIV.B.DE316
 * confirmatorySyphilisTestType 0..* Coding "Confirmatory syphilis test type" "Type of test ued for confirmatory syphilis test"
   * ^code[+] = HIVConcepts#HIV.B.DE317
-  * confirmatorySyphilisTestType from HIV.B.DE317
-* other 0..1 string "Other (specify)" "Other test used for confirmatory syphilis test (specify)"
+* confirmatorySyphilisTestType from HIV.B.DE317
+* otherConfirmatorySyphilisTestType 0..1 string "Other (specify)" "Other test used for confirmatory syphilis test (specify)"
   * ^code[+] = HIVConcepts#HIV.B.DE323
-* confirmatoryTestTypeForOtherSti 0..1 string "Confirmatory test type for other STI (specify)" "Confirmatory test type for other STI"
+* confirmatoryTestTypeForOtherStiSpecify 0..1 string "Confirmatory test type for other STI (specify)" "Confirmatory test type for other STI"
   * ^code[+] = HIVConcepts#HIV.B.DE324
 * confirmatoryStiTestResult 0..1 Coding "Confirmatory STI test result" "Result from confirmatory STI test"
   * ^code[+] = HIVConcepts#HIV.B.DE325
-  * confirmatoryStiTestResult from HIV.B.DE325
+* confirmatoryStiTestResult from HIV.B.DE325
 * dateStiTreatmentPrescribed 0..1 dateTime "Date STI treatment prescribed" "Date STI treatment was prescribed to the client"
   * ^code[+] = HIVConcepts#HIV.B.DE329
 * dateStiTreatmentDispensed 0..1 dateTime "Date STI treatment dispensed" "Date STI treatment dispensed to the client"
   * ^code[+] = HIVConcepts#HIV.B.DE330
-* stiTreatmentDispensed 0..1 string "STI treatment dispensed (specify)" "STI treatment dispensed to the client"
+* stiTreatmentDispensedSpecify 0..1 string "STI treatment dispensed (specify)" "STI treatment dispensed to the client"
   * ^code[+] = HIVConcepts#HIV.B.DE331

--- a/input/fsh/models/HIVCPrEPvisit.fsh
+++ b/input/fsh/models/HIVCPrEPvisit.fsh
@@ -25,10 +25,10 @@ Description: "This tab describes the data that may be collected during the pre-e
 
 * reasonForPrepVisit 1..1 Coding "Reason for PrEP visit" "Client's reason for the prevention visit"
   * ^code[+] = HIVConcepts#HIV.C.DE1
-  * reasonForPrepVisit from HIV.C.DE1
-* 3MonthPrepVisit 0..1 boolean "3-month PrEP visit" "Client is visiting for the recommended 3-month pre-exposure prophylaxis (PrEP) visit"
+* reasonForPrepVisit from HIV.C.DE1
+* threeMonthPrepVisit 0..1 boolean "3-month PrEP visit" "Client is visiting for the recommended 3-month pre-exposure prophylaxis (PrEP) visit"
   * ^code[+] = HIVConcepts#HIV.C.DE7
-* contactWithAnduspecteexposureToHiv 0..1 boolean "Contact with and (suspected) exposure to HIV" "The client had suspected or known exposure to HIV"
+* contactWithAndSuspectedExposureToHiv 0..1 boolean "Contact with and (suspected) exposure to HIV" "The client had suspected or known exposure to HIV"
   * ^code[+] = HIVConcepts#HIV.C.DE8
 * dateTimeOfSuspectedExposureToHiv 0..1 dateTime "Date/time of suspected exposure to HIV" "When the suspect exposure to HIV took place"
   * ^code[+] = HIVConcepts#HIV.C.DE9
@@ -36,17 +36,17 @@ Description: "This tab describes the data that may be collected during the pre-e
   * ^code[+] = HIVConcepts#HIV.C.DE10
 * prepDosingType 0..1 Coding "PrEP dosing type" "Way in which pre-exposure prophylaxis (PrEP) is taken (daily or event-driven)"
   * ^code[+] = HIVConcepts#HIV.C.DE11
-  * prepDosingType from HIV.C.DE11
-* otherPrepDosingType 0..1 string "Other PrEP dosing type (specify)" "Other PrEP dosing type (specify)"
+* prepDosingType from HIV.C.DE11
+* otherPrepDosingTypeSpecify 0..1 string "Other PrEP dosing type (specify)" "Other PrEP dosing type (specify)"
   * ^code[+] = HIVConcepts#HIV.C.DE15
-* usedEventDrivenPrepForAtRiskExposuresOverThePast_3Months 0..1 boolean "Used event-driven PrEP for at risk exposures over the past 3 months" "Client reports taking ED-PrEP for at risk exposures over a 3-month period"
+* usedEventDrivenPrepForAtRiskExposuresOverThePast3Months 0..1 boolean "Used event-driven PrEP for at risk exposures over the past 3 months" "Client reports taking ED-PrEP for at risk exposures over a 3-month period"
   * ^code[+] = HIVConcepts#HIV.C.DE16
 * currentPrepRegimen 0..1 Coding "Current PrEP regimen" "HIV pre-exposure prophylaxis (PrEP) regimen"
   * ^code[+] = HIVConcepts#HIV.C.DE17
-  * currentPrepRegimen from HIV.C.DE17
+* currentPrepRegimen from HIV.C.DE17
 * experienceWithPrep 0..1 Coding "Experience with PrEP" "The client's experience in taking PrEP"
   * ^code[+] = HIVConcepts#HIV.C.DE24
-  * experienceWithPrep from HIV.C.DE24
+* experienceWithPrep from HIV.C.DE24
 * prepStartDate 0..1 date "PrEP start date" "The date on which the client started or restarted pre-exposure prophylaxis (PrEP)"
   * ^code[+] = HIVConcepts#HIV.C.DE28
 * stoppedPrep 0..1 boolean "Stopped PrEP" "Client stopped taking pre-exposure prophylaxis (PrEP)"
@@ -55,30 +55,30 @@ Description: "This tab describes the data that may be collected during the pre-e
   * ^code[+] = HIVConcepts#HIV.C.DE30
 * pepHistory 0..1 Coding "PEP history" "The client's history in taking post-exposure prophylaxis (PEP) for HIV prevention"
   * ^code[+] = HIVConcepts#HIV.C.DE31
-  * pepHistory from HIV.C.DE31
-* dat)OfPastPepUse 0..1 date "Date(s) of past PEP use" "Dates when the client previously used post-exposure prophylaxis (PEP)"
+* pepHistory from HIV.C.DE31
+* datesOfPastPepUse 0..1 date "Date(s) of past PEP use" "Dates when the client previously used post-exposure prophylaxis (PEP)"
   * ^code[+] = HIVConcepts#HIV.C.DE34
 * dateClientCompletesPepCourse 0..1 date "Date client completes PEP course" "Date client completes PEP course"
   * ^code[+] = HIVConcepts#HIV.C.DE35
 * signsOfSubstantialRiskOfHivInfection 1..* Coding "Signs of substantial risk of HIV infection" "Signs the client is at a substantial risk of HIV infection"
   * ^code[+] = HIVConcepts#HIV.C.DE36
-  * signsOfSubstantialRiskOfHivInfection from HIV.C.DE36
+* signsOfSubstantialRiskOfHivInfection from HIV.C.DE36
 * pregnancyIntentionInSerodiscordantPartnerships 1..1 Coding "Pregnancy intention in serodiscordant partnerships" "Client's intention or desire in the next year to either become pregnant or prevent a future pregnancy (in serodiscordant partnerships)"
   * ^code[+] = HIVConcepts#HIV.C.DE41
-  * pregnancyIntentionInSerodiscordantPartnerships from HIV.C.DE41
+* pregnancyIntentionInSerodiscordantPartnerships from HIV.C.DE41
 * acuteHivInfectionSymptoms 0..* Coding "Acute HIV infection symptoms" "Symptoms that could suggest an acute HIV infection"
   * ^code[+] = HIVConcepts#HIV.C.DE46
-  * acuteHivInfectionSymptoms from HIV.C.DE46
+* acuteHivInfectionSymptoms from HIV.C.DE46
 * sexPartnerHivTreatmentStatus 0..* Coding "Sex partner's HIV treatment status" "Treatment adherence of client's sex partner for partners that are HIV-positive"
   * ^code[+] = HIVConcepts#HIV.C.DE55
-  * sexPartnerHivTreatmentStatus from HIV.C.DE55
+* sexPartnerHivTreatmentStatus from HIV.C.DE55
 * suitableForPrep 0..1 boolean "Suitable for PrEP" "The client is suitable for PrEP"
   * ^code[+] = HIVConcepts#HIV.C.DE61
 * offeredPrep 0..1 boolean "Offered PrEP" "After being evaluated as suitable for PrEP, the client was offered PrEP"
   * ^code[+] = HIVConcepts#HIV.C.DE62
 * screeningsAndDiagnosticsForPrepUsers 0..* Coding "Screenings and diagnostics for PrEP users" "Listing of tests for clients on or starting pre-exposure prophylaxis (PrEP) that may be recommended or should be considered"
   * ^code[+] = HIVConcepts#HIV.C.DE63
-  * screeningsAndDiagnosticsForPrepUsers from HIV.C.DE63
+* screeningsAndDiagnosticsForPrepUsers from HIV.C.DE63
 * serumCreatinineTestDate 0..1 date "Serum creatinine test date" "Test serum creatinine to identify pre-existing renal disease (estimated creatinine clearance less than 60 ml/min)"
   * ^code[+] = HIVConcepts#HIV.C.DE71
 * serumCreatinineTestResult 0..1 integer "Serum creatinine test result" "Test serum creatinine to identify pre-existing renal disease (estimated creatinine clearance less than 60 ml/min)."
@@ -89,13 +89,13 @@ Description: "This tab describes the data that may be collected during the pre-e
   * ^code[+] = HIVConcepts#HIV.C.DE74
 * medicationsPrescribed 0..1 Coding "Medications prescribed" "Medications the client was prescribed"
   * ^code[+] = HIVConcepts#HIV.C.DE75
-  * medicationsPrescribed from HIV.C.DE75
-* other 0..1 string "Other (specify)" "Client was prescribed other medications (specify)"
+* medicationsPrescribed from HIV.C.DE75
+* otherMedicationsPrescribed 0..1 string "Other (specify)" "Client was prescribed other medications (specify)"
   * ^code[+] = HIVConcepts#HIV.C.DE79
 * prepProductPrescribed 0..1 Coding "PrEP product prescribed" "PrEP product that the client was prescribed"
   * ^code[+] = HIVConcepts#HIV.C.DE80
-  * prepProductPrescribed from HIV.C.DE80
-* other 0..1 string "Other (specify)" "Client was prescribed other PrEP product (specify)"
+* prepProductPrescribed from HIV.C.DE80
+* otherPrepProductPrescribed 0..1 string "Other (specify)" "Client was prescribed other PrEP product (specify)"
   * ^code[+] = HIVConcepts#HIV.C.DE85
 * datePrepPrescribed 0..1 date "Date PrEP prescribed" "Date client was prescribed PrEP, including initial prescription and repeats"
   * ^code[+] = HIVConcepts#HIV.C.DE86
@@ -109,29 +109,29 @@ Description: "This tab describes the data that may be collected during the pre-e
   * ^code[+] = HIVConcepts#HIV.C.DE90
 * preferredPepBackboneRegimen 0..1 Coding "Preferred PEP backbone regimen" "Preferred backbone regimen for PEP"
   * ^code[+] = HIVConcepts#HIV.C.DE91
-  * preferredPepBackboneRegimen from HIV.C.DE91
+* preferredPepBackboneRegimen from HIV.C.DE91
 * alternativePepBackboneRegimen 0..* Coding "Alternative PEP backbone regimen" "Alternative backbone regimen for PEP"
   * ^code[+] = HIVConcepts#HIV.C.DE95
-  * alternativePepBackboneRegimen from HIV.C.DE95
+* alternativePepBackboneRegimen from HIV.C.DE95
 * preferredThirdPepDrug 0..* Coding "Preferred third PEP drug" "Preferred third drug for PEP"
   * ^code[+] = HIVConcepts#HIV.C.DE99
-  * preferredThirdPepDrug from HIV.C.DE99
+* preferredThirdPepDrug from HIV.C.DE99
 * alternativeThirdPepDrug 0..* Coding "Alternative third PEP drug" "Alternative third drug for PEP"
   * ^code[+] = HIVConcepts#HIV.C.DE101
-  * alternativeThirdPepDrug from HIV.C.DE101
+* alternativeThirdPepDrug from HIV.C.DE101
 * estimatedCreatinineClearance 0..1 integer "Estimated creatinine clearance" "Estimated creatinine clearance of the client returned from lab in mL/min"
   * ^code[+] = HIVConcepts#HIV.C.DE106
 * sexFactorForEstimatingCreatinineClearance 0..1 Coding "Sex factor for estimating creatinine clearance" "Value used for gender for calculating creatinine clearance if required. For transgender populations, the sex at birth is used in the Cockcroft-Gault equation if the person is not using hormone therapy; among transgender populations using hormone therapy for more than three months, the current gender can be used."
   * ^code[+] = HIVConcepts#HIV.C.DE107
-  * sexFactorForEstimatingCreatinineClearance from HIV.C.DE107
-* estimatedCreatinineClearance 0..1 integer "Estimated creatinine clearance (Cockcroft–Gault equation)" "If the laboratory does not have the capacity to estimate creatinine clearance, the provider can use the Cockcroft–Gault equation to calculate estimated creatinine clearance based on measured serum creatinine, the client’s sex at birth, age and estimated lean body weight."
+* sexFactorForEstimatingCreatinineClearance from HIV.C.DE107
+* estimatedCreatinineClearanceCockcroftGaultEquation 0..1 integer "Estimated creatinine clearance (Cockcroft–Gault equation)" "If the laboratory does not have the capacity to estimate creatinine clearance, the provider can use the Cockcroft–Gault equation to calculate estimated creatinine clearance based on measured serum creatinine, the client’s sex at birth, age and estimated lean body weight."
   * ^code[+] = HIVConcepts#HIV.C.DE110
 * dateOfSampleCollection 0..1 dateTime "Date of sample collection" "Date when the specimen was collected"
   * ^code[+] = HIVConcepts#HIV.C.DE111
 * contraindicationsToPrepUsage 0..* Coding "Contraindications to PrEP usage" "Listing of contraindications to pre-exposure prophylaxis (PrEP)"
   * ^code[+] = HIVConcepts#HIV.C.DE112
-  * contraindicationsToPrepUsage from HIV.C.DE112
-* otherAllergyOrContraindicationToAMedicineInThePrepRegimen 0..1 string "Other allergy or contraindication to a medicine in the PrEP regimen (specify)" "Client has another allergy or contraindication to a medicine in the pre-exposure prophylaxis (PrEP) regimen (specify)"
+* contraindicationsToPrepUsage from HIV.C.DE112
+* otherAllergyOrContraindicationToAMedicineInThePrepRegimenSpecify 0..1 string "Other allergy or contraindication to a medicine in the PrEP regimen (specify)" "Client has another allergy or contraindication to a medicine in the pre-exposure prophylaxis (PrEP) regimen (specify)"
   * ^code[+] = HIVConcepts#HIV.C.DE119
 * prescribedPrepAtInitialVisit 0..1 boolean "Prescribed PrEP at initial visit" "Client was prescribed pre-exposure prophylaxis (PrEP) on a first visit"
   * ^code[+] = HIVConcepts#HIV.C.DE120
@@ -139,41 +139,41 @@ Description: "This tab describes the data that may be collected during the pre-e
   * ^code[+] = HIVConcepts#HIV.C.DE121
 * prepRegimenPrescribed 0..* Coding "PrEP regimen prescribed" "HIV pre-exposure prophylaxis (PrEP) regimen prescribed"
   * ^code[+] = HIVConcepts#HIV.C.DE122
-  * prepRegimenPrescribed from HIV.C.DE122
+* prepRegimenPrescribed from HIV.C.DE122
 * adherenceCounsellingProvided 0..1 boolean "Adherence counselling provided" "Whether adherence counselling was provided"
   * ^code[+] = HIVConcepts#HIV.C.DE123
 * dateTimeOfFollowUpAppointment 0..1 dateTime "Date/time of follow-up appointment" "Date the client is to return for monitoring, re-supply, or any other reason"
   * ^code[+] = HIVConcepts#HIV.C.DE124
 * typeOfFollowUpAppointment 0..1 Coding "Type of follow-up appointment" "Type of follow-up appointment for testing services"
   * ^code[+] = HIVConcepts#HIV.C.DE125
-  * typeOfFollowUpAppointment from HIV.C.DE125
-* other 0..1 string "Other (specify)" "Other reason for the follow-up appointment (specify)"
+* typeOfFollowUpAppointment from HIV.C.DE125
+* otherTypeOfFollowUpAppointment 0..1 string "Other (specify)" "Other reason for the follow-up appointment (specify)"
   * ^code[+] = HIVConcepts#HIV.C.DE129
 * linkedToEnrolmentInCareAndArtInitiation 0..1 boolean "Linked to enrolment in care and ART initiation" "Linkage made from HIV testing to enrolment in care following an HIV diagnosis"
   * ^code[+] = HIVConcepts#HIV.C.DE130
 * preventionServicesOfferedAndReferrals 0..* Coding "Prevention services offered and referrals" "Offer or refer to prevention services"
   * ^code[+] = HIVConcepts#HIV.C.DE131
-  * preventionServicesOfferedAndReferrals from HIV.C.DE131
+* preventionServicesOfferedAndReferrals from HIV.C.DE131
 * dateProvidedCondoms 0..1 date "Date provided condoms" "Date client was provided with condoms"
   * ^code[+] = HIVConcepts#HIV.C.DE136
 * condomsDistributed 0..1 integer "Condoms distributed" "Number of condoms given to the client, if any were distributed"
   * ^code[+] = HIVConcepts#HIV.C.DE137
 * condomType 0..1 Coding "Condom type" "Type of condom provided to client"
   * ^code[+] = HIVConcepts#HIV.C.DE138
-  * condomType from HIV.C.DE138
+* condomType from HIV.C.DE138
 * hivSelfTestKitsAccepted 0..1 boolean "HIV self-test kits accepted" "Whether any HIV self-test kits were given to the client"
   * ^code[+] = HIVConcepts#HIV.C.DE141
 * numberOfHivSelfTestKitsDistributed 0..1 integer "Number of HIV self-test kits distributed" "Number of HIV self-test kits distributed to the client"
   * ^code[+] = HIVConcepts#HIV.C.DE142
 * hivSelfTestDistributedForUseBy 0..1 Coding "HIV self-test distributed for use by" "Whom the client plans to give the HIV self-test kit (self, sexual partner, social contact, etc.)"
   * ^code[+] = HIVConcepts#HIV.C.DE143
-  * hivSelfTestDistributedForUseBy from HIV.C.DE143
+* hivSelfTestDistributedForUseBy from HIV.C.DE143
 * sexualAndReproductiveHealthIntegratedServices 0..* Coding "Sexual and reproductive health integrated services" "Offer or refer to sexual and reproductive health services"
   * ^code[+] = HIVConcepts#HIV.C.DE149
-  * sexualAndReproductiveHealthIntegratedServices from HIV.C.DE149
+* sexualAndReproductiveHealthIntegratedServices from HIV.C.DE149
 * offerOtherClinicalServices 0..* Coding "Offer other clinical services" "Other clinical services offered or referrals given to the client"
   * ^code[+] = HIVConcepts#HIV.C.DE157
-  * offerOtherClinicalServices from HIV.C.DE157
+* offerOtherClinicalServices from HIV.C.DE157
 * otherSupportServices 0..* Coding "Other support services" "Offer or refer for other support services"
   * ^code[+] = HIVConcepts#HIV.C.DE164
-  * otherSupportServices from HIV.C.DE164
+* otherSupportServices from HIV.C.DE164

--- a/input/fsh/models/HIVConfiguration.fsh
+++ b/input/fsh/models/HIVConfiguration.fsh
@@ -77,7 +77,7 @@ Description: "This tab describes data about a facility or region that are used i
   * ^code[+] = HIVConcepts#HIV.Config.DE11
 * hivBurdenOfTheSetting 1..1 Coding "HIV burden of the setting" "HIV burden of the setting (high or low) based on the national HIV prevalence or where the HIV prevalence and/or incidence in a geographical setting is higher than national prevalence and, therefore, needs priority in the HIV response"
   * ^code[+] = HIVConcepts#HIV.Config.DE12
-  * hivBurdenOfTheSetting from HIV.Config.DE12
+* hivBurdenOfTheSetting from HIV.Config.DE12
 * hpvDnaTestingOperationalAtTheHealthFacility 1..1 boolean "HPV DNA testing operational at the health facility" "Is HPV DNA testing operational at the health facility for cervical cancer screening?"
   * ^code[+] = HIVConcepts#HIV.Config.DE15
 * routineViralLoadTestingIsAvailable 1..1 boolean "Routine viral load testing is available" "Routine viral load testing is available in the facility"
@@ -88,7 +88,7 @@ Description: "This tab describes data about a facility or region that are used i
   * ^code[+] = HIVConcepts#HIV.Config.DE18
 * otherPriorityPopulations 0..1 Coding "Other priority populations" "Other populations of priority of HIV prevention and care in local context (provided during adaptation)"
   * ^code[+] = HIVConcepts#HIV.Config.DE19
-  * otherPriorityPopulations from HIV.Config.DE19
+* otherPriorityPopulations from HIV.Config.DE19
 * reportingPeriodEndDate 0..1 date "Reporting period end date" "End date of the reporting period"
   * ^code[+] = HIVConcepts#HIV.Config.DE20
 * reportingPeriodStartDate 0..1 date "Reporting period start date" "Start date of the reporting period"

--- a/input/fsh/models/HIVDCareTreatment.fsh
+++ b/input/fsh/models/HIVDCareTreatment.fsh
@@ -90,7 +90,7 @@ Description: "This tab describes the data that may be collected during care and 
 
 * reasonForVisit 1..* Coding "Reason for visit" "Whether visit was scheduled or unscheduled, clinical only, or for ARV drug pick-up"
   * ^code[+] = HIVConcepts#HIV.D.DE1
-  * reasonForVisit from HIV.D.DE1
+* reasonForVisit from HIV.D.DE1
 * scheduledVisit 1..1 boolean "Scheduled visit" "Is this is a scheduled visit?"
   * ^code[+] = HIVConcepts#HIV.D.DE8
 * bodyTemperature 0..1 integer "Body temperature" "Temperature of the client in Celsius"
@@ -111,14 +111,14 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE16
 * signsOfSeriousIllness 0..* Coding "Signs of serious illness" "Signs that may indicate the client has a serious illness and needs triage or an emergency referral"
   * ^code[+] = HIVConcepts#HIV.D.DE17
-  * signsOfSeriousIllness from HIV.D.DE17
-* otherSignOfSeriousIllness 0..1 string "Other sign of serious illness (specify)" "Client is exhibiting another sign of a serious illness (specify)"
+* signsOfSeriousIllness from HIV.D.DE17
+* otherSignOfSeriousIllnessSpecify 0..1 string "Other sign of serious illness (specify)" "Client is exhibiting another sign of a serious illness (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE30
 * currentlyPregnant 0..1 boolean "Currently pregnant" "Client is currently pregnant"
   * ^code[+] = HIVConcepts#HIV.D.DE31
 * breastfeeding 0..1 boolean "Breastfeeding" "Client is giving infant breast milk"
   * ^code[+] = HIVConcepts#HIV.D.DE32
-* numberOfPregnancies 0..1 integer "Number of pregnancies (gravida)" "Total number of times the woman has been pregnant (gravida)"
+* numberOfPregnanciesGravida 0..1 integer "Number of pregnancies (gravida)" "Total number of times the woman has been pregnant (gravida)"
   * ^code[+] = HIVConcepts#HIV.D.DE33
 * numberOfMiscarriagesAndOrAbortions 0..1 integer "Number of miscarriages and/or abortions" "Total number of pregnancies lost/ended due to miscarriages and/or abortions before 22 weeks/5 months"
   * ^code[+] = HIVConcepts#HIV.D.DE34
@@ -140,12 +140,12 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE42
 * artStartType 0..1 Coding "ART start type" "Whether the client is ART naive or is restarting ART"
   * ^code[+] = HIVConcepts#HIV.D.DE43
-  * artStartType from HIV.D.DE43
+* artStartType from HIV.D.DE43
 * dateOfInitiationOnArt 0..1 date "Date of initiation on ART" "The date on which the client was first initiated on ART"
   * ^code[+] = HIVConcepts#HIV.D.DE46
 * timeOnArt 0..1 integer "Time on ART" "Time the client has been on ART since starting or restarting it in years and months"
   * ^code[+] = HIVConcepts#HIV.D.DE47
-* dat)ArtRestarted 0..1 date "Date(s) ART restarted" "Date(s) client restarted ART after stopping (intentionally interrupting) for any number of reasons (see 'Reason ART stopped')"
+* datesArtRestarted 0..1 date "Date(s) ART restarted" "Date(s) client restarted ART after stopping (intentionally interrupting) for any number of reasons (see 'Reason ART stopped')"
   * ^code[+] = HIVConcepts#HIV.D.DE48
 * artCohort 0..1 date "ART cohort" "Month and year client originally started ART (documented) at a health facility in the system. The cohort is a group of patients who started ART in the same month (or quarter) and year, whose status is followed over time, using the ART register."
   * ^code[+] = HIVConcepts#HIV.D.DE49
@@ -155,93 +155,93 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE51
 * facilityTransferredFrom 0..1 Coding "Facility transferred from" "Name of health facility client was transferred from"
   * ^code[+] = HIVConcepts#HIV.D.DE52
-  * facilityTransferredFrom from HIV.D.DE52
+* facilityTransferredFrom from HIV.D.DE52
 * dateEnrolledInHivCare 0..1 date "Date enrolled in HIV care" "Date client first enrols in HIV care at the facility. Begins when a person with a confirmed HIV diagnosis presents to a facility where HIV care is provided and a medical record, patient card, file or chart is opened for the first time. This could be at an HIV care/ART, MNCH or TB clinic."
   * ^code[+] = HIVConcepts#HIV.D.DE53
 * ageAtEnrolment 0..1 integer "Age at enrolment" "Client's age when the client was enrolled in ART care"
   * ^code[+] = HIVConcepts#HIV.D.DE54
 * facilityWhereClientFirstEnrolledInHivCare 0..1 Coding "Facility where client first enrolled in HIV care" "Facility where the client first enrolled in HIV care"
   * ^code[+] = HIVConcepts#HIV.D.DE55
-  * facilityWhereClientFirstEnrolledInHivCare from HIV.D.DE55
-* antiretroviralrdrugsReceivedPriorToEnrolment 0..1 Coding "Antiretroviral (ARV) drugs received prior to enrolment" "Whether or not the client received ARV drugs prior to enrolling into HIV care"
+* facilityWhereClientFirstEnrolledInHivCare from HIV.D.DE55
+* antiretroviralArvDrugsReceivedPriorToEnrolment 0..1 Coding "Antiretroviral (ARV) drugs received prior to enrolment" "Whether or not the client received ARV drugs prior to enrolling into HIV care"
   * ^code[+] = HIVConcepts#HIV.D.DE56
-  * antiretroviralrdrugsReceivedPriorToEnrolment from HIV.D.DE56
+* antiretroviralArvDrugsReceivedPriorToEnrolment from HIV.D.DE56
 * dateArvDrugsReceivedPriorToEnrolment 0..1 date "Date ARV drugs received prior to enrolment" "Date ARV drugs were started prior to enrolment into HIV care/ART"
   * ^code[+] = HIVConcepts#HIV.D.DE62
 * locationArvDrugsReceivedPriorToEnrolment 0..1 Coding "Location ARV drugs received prior to enrolment" "Health facility (or other location) where ARV drugs were received prior to enrolment into HIV care/ART"
   * ^code[+] = HIVConcepts#HIV.D.DE63
-  * locationArvDrugsReceivedPriorToEnrolment from HIV.D.DE63
+* locationArvDrugsReceivedPriorToEnrolment from HIV.D.DE63
 * arvDrugRegimenReceivedPriorToEnrolment 0..1 Coding "ARV drug regimen received prior to enrolment" "ARV drug regimen received prior to enrolment into HIV care/ART"
   * ^code[+] = HIVConcepts#HIV.D.DE64
-  * arvDrugRegimenReceivedPriorToEnrolment from HIV.D.DE64
+* arvDrugRegimenReceivedPriorToEnrolment from HIV.D.DE64
 * existingChronicHealthConditions 0..* Coding "Existing chronic health conditions" "Does the client have any current chronic health conditions or problems?"
   * ^code[+] = HIVConcepts#HIV.D.DE65
-  * existingChronicHealthConditions from HIV.D.DE65
-* other 0..1 string "Other (specify)" "Other health conditions not included in the list (specify)"
+* existingChronicHealthConditions from HIV.D.DE65
+* otherExistingChronicHealthConditions 0..1 string "Other (specify)" "Other health conditions not included in the list (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE73
 * originalFirstLineArtRegimen 0..1 Coding "Original first-line ART regimen" "Original full, first-line ARV drug regimen patient started on at this facility"
   * ^code[+] = HIVConcepts#HIV.D.DE74
-  * originalFirstLineArtRegimen from HIV.D.DE74
+* originalFirstLineArtRegimen from HIV.D.DE74
 * currentArtRegimen 0..1 Coding "Current ART regimen" "The current ART regimen the client is taking"
   * ^code[+] = HIVConcepts#HIV.D.DE75
-  * currentArtRegimen from HIV.D.DE75
+* currentArtRegimen from HIV.D.DE75
 * currentArtRegimenStartDate 0..1 date "Current ART regimen start date" "The date on which the client started taking the current ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE76
 * preferredFirstLineArtRegimen 0..* Coding "Preferred first-line ART regimen" "The preferred first-line ART regimen for the client according to WHO (or national) guidelines"
   * ^code[+] = HIVConcepts#HIV.D.DE77
-  * preferredFirstLineArtRegimen from HIV.D.DE77
+* preferredFirstLineArtRegimen from HIV.D.DE77
 * alternativeFirstLineArtRegimen 0..* Coding "Alternative first-line ART regimen" "The alternative first-line ART regimen for the client according to WHO (or national) guidelines"
   * ^code[+] = HIVConcepts#HIV.D.DE78
-  * alternativeFirstLineArtRegimen from HIV.D.DE78
+* alternativeFirstLineArtRegimen from HIV.D.DE78
 * firstLineArtRegimenUnderSpecialCircumstances 0..* Coding "First-line ART regimen under special circumstances" "The first-line ART regimen for the client under special circumstances according to WHO (or national) guidelines"
   * ^code[+] = HIVConcepts#HIV.D.DE79
-  * firstLineArtRegimenUnderSpecialCircumstances from HIV.D.DE79
+* firstLineArtRegimenUnderSpecialCircumstances from HIV.D.DE79
 * preferredSecondLineArtRegimen 0..* Coding "Preferred second-line ART regimen" "The preferred second-line ART regimen for the client according to WHO (or national) guidelines"
   * ^code[+] = HIVConcepts#HIV.D.DE80
-  * preferredSecondLineArtRegimen from HIV.D.DE80
+* preferredSecondLineArtRegimen from HIV.D.DE80
 * alternativeSecondLineArtRegimen 0..* Coding "Alternative second-line ART regimen" "The alternative second-line ART regimen for the client according to WHO (or national) guidelines"
   * ^code[+] = HIVConcepts#HIV.D.DE81
-  * alternativeSecondLineArtRegimen from HIV.D.DE81
+* alternativeSecondLineArtRegimen from HIV.D.DE81
 * optimalRegimenForTransition 0..* Coding "Optimal regimen for transition" "The optimal regimen for transition to DTG-based regimens for children established on ART"
   * ^code[+] = HIVConcepts#HIV.D.DE82
-  * optimalRegimenForTransition from HIV.D.DE82
-* currentArtRegimen 0..1 Coding "Current ART regimen (first-, second-, or third-line)" "ART regimen for treating clients living with HIV, based on national guidance"
+* optimalRegimenForTransition from HIV.D.DE82
+* currentArtRegimenFirstSecondOrThirdLine 0..1 Coding "Current ART regimen (first-, second-, or third-line)" "ART regimen for treating clients living with HIV, based on national guidance"
   * ^code[+] = HIVConcepts#HIV.D.DE83
-  * currentArtRegimen from HIV.D.DE83
+* currentArtRegimenFirstSecondOrThirdLine from HIV.D.DE83
 * artRegimen 0..1 Coding "ART regimen" "List of ART regimens"
   * ^code[+] = HIVConcepts#HIV.D.DE90
-  * artRegimen from HIV.D.DE90
-* other 0..1 string "Other (specify)" "Other regimen based upon WHO recommendations (specify)"
+* artRegimen from HIV.D.DE90
+* otherArtRegimen 0..1 string "Other (specify)" "Other regimen based upon WHO recommendations (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE127
 * artRegimenComposition 0..* Coding "ART regimen composition" "Drug composition of client's current ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE128
-  * artRegimenComposition from HIV.D.DE128
+* artRegimenComposition from HIV.D.DE128
 * artRegimenDrugClass 0..* Coding "ART regimen drug class" "Drug class of current ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE146
-  * artRegimenDrugClass from HIV.D.DE146
+* artRegimenDrugClass from HIV.D.DE146
 * preventionServicesOfferedAndReferrals 1..* Coding "Prevention services offered and referrals" "Offer or refer for prevention services"
   * ^code[+] = HIVConcepts#HIV.D.DE152
-  * preventionServicesOfferedAndReferrals from HIV.D.DE152
+* preventionServicesOfferedAndReferrals from HIV.D.DE152
 * sexualAndReproductiveHealthIntegratedServices 1..* Coding "Sexual and reproductive health integrated services" "Offer or refer to sexual and reproductive health services"
   * ^code[+] = HIVConcepts#HIV.D.DE156
-  * sexualAndReproductiveHealthIntegratedServices from HIV.D.DE156
+* sexualAndReproductiveHealthIntegratedServices from HIV.D.DE156
 * hbsagTestDate 0..1 date "HBsAg test date" "Date client was tested for hepatitis B virus (HBV)"
   * ^code[+] = HIVConcepts#HIV.D.DE161
 * hbsagTestResult 0..1 Coding "HBsAg test result" "Hepatitis B virus test result (HBsAg)"
   * ^code[+] = HIVConcepts#HIV.D.DE162
-  * hbsagTestResult from HIV.D.DE162
+* hbsagTestResult from HIV.D.DE162
 * dateHbvTestResultReturnedToClient 0..1 date "Date HBV test result returned to client" "Date HBV test result (HBsAG) was returned to client"
   * ^code[+] = HIVConcepts#HIV.D.DE166
-* hbvTreatmentdstartDate 0..1 date "HBV treatment (TDF) start date" "Date when client started treatment (TDF) for hepatitis B virus (HBV)"
+* hbvTreatmentTdfStartDate 0..1 date "HBV treatment (TDF) start date" "Date when client started treatment (TDF) for hepatitis B virus (HBV)"
   * ^code[+] = HIVConcepts#HIV.D.DE167
 * hbvTreatmentRegimenPrescribed 0..1 Coding "HBV treatment regimen prescribed" "Hepatitis B virus treatment regimen prescribed"
   * ^code[+] = HIVConcepts#HIV.D.DE168
-  * hbvTreatmentRegimenPrescribed from HIV.D.DE168
+* hbvTreatmentRegimenPrescribed from HIV.D.DE168
 * hcvTestDate 0..1 date "HCV test date" "Date client was tested for hepatitis C virus (HCV antibody, HCV RNA or HCV core antigen)"
   * ^code[+] = HIVConcepts#HIV.D.DE169
 * hcvTestResult 0..1 Coding "HCV test result" "Hepatitis C virus test result (HCV antibody, HCV RNA or HCV core antigen)"
   * ^code[+] = HIVConcepts#HIV.D.DE170
-  * hcvTestResult from HIV.D.DE170
+* hcvTestResult from HIV.D.DE170
 * dateHcvTestResultReturnedToClient 0..1 date "Date HCV test result returned to client" "Date HCV test result was returned to client"
   * ^code[+] = HIVConcepts#HIV.D.DE174
 * hcvTreatmentStartDate 0..1 date "HCV treatment start date" "Date when client started treatment for hepatitis C virus (HCV)"
@@ -250,20 +250,20 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE176
 * hcvTreatmentRegimenPrescribed 0..1 Coding "HCV treatment regimen prescribed" "Hepatitis C virus treatment regimen prescribed"
   * ^code[+] = HIVConcepts#HIV.D.DE177
-  * hcvTreatmentRegimenPrescribed from HIV.D.DE177
+* hcvTreatmentRegimenPrescribed from HIV.D.DE177
 * hcvViralLoadTestDate 0..1 date "HCV viral load test date" "Hepatitis C viral load test date"
   * ^code[+] = HIVConcepts#HIV.D.DE178
 * hcvViralLoadTestResult 0..1 Coding "HCV viral load test result" "Hepatitis C viral load test result (qualitative)"
   * ^code[+] = HIVConcepts#HIV.D.DE179
-  * hcvViralLoadTestResult from HIV.D.DE179
+* hcvViralLoadTestResult from HIV.D.DE179
 * hcvMedicineType 0..1 Coding "HCV medicine type" "Type of medicine client is prescribed"
   * ^code[+] = HIVConcepts#HIV.D.DE182
-  * hcvMedicineType from HIV.D.DE182
+* hcvMedicineType from HIV.D.DE182
 * currentlyOnTdfBasedArt 0..1 boolean "Currently on TDF-based ART" "Client is currently on TDF-based ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE185
 * hivClinicalStage 0..1 Coding "HIV clinical stage" "WHO clinical stage of client based on signs and symptoms. WHO clinical staging is a way to categorize HIV disease severity based on new or recurrent clinical events. There are 4 WHO clinical stages that range from mild symptoms (WHO clinical stage 1) to severe symptoms (WHO clinical stage 4)."
   * ^code[+] = HIVConcepts#HIV.D.DE186
-  * hivClinicalStage from HIV.D.DE186
+* hivClinicalStage from HIV.D.DE186
 * numberOfMissedDoses 0..1 integer "Number of missed doses" "Number of doses of antiretroviral therapy (ART) the client missed since the last visit, used for monitoring adherence"
   * ^code[+] = HIVConcepts#HIV.D.DE191
 * receivedViralLoadTestResult 0..1 boolean "Received viral load test result" "Client received results from viral load test"
@@ -276,36 +276,36 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE195
 * dateOfArtInterruption 0..1 date "Date of ART interruption" "Date of client's ART interruption (ART stop or missed drug pick-up)"
   * ^code[+] = HIVConcepts#HIV.D.DE196
-* reaso)ForAdherenceProblem 0..* Coding "Reason(s) for adherence problem" "Reason why client was not adherent"
+* reasonsForAdherenceProblem 0..* Coding "Reason(s) for adherence problem" "Reason why client was not adherent"
   * ^code[+] = HIVConcepts#HIV.D.DE197
-  * reaso)ForAdherenceProblem from HIV.D.DE197
-* otherReasonForNonadherence 0..1 string "Other reason for nonadherence (specify)" "Client reported not being adherent because of other reason for nonadherence (specify)"
+* reasonsForAdherenceProblem from HIV.D.DE197
+* otherReasonForNonadherenceSpecify 0..1 string "Other reason for nonadherence (specify)" "Client reported not being adherent because of other reason for nonadherence (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE216
 * reasonArtStopped 0..* Coding "Reason ART stopped" "Reason client intentionally stopped ART"
   * ^code[+] = HIVConcepts#HIV.D.DE217
-  * reasonArtStopped from HIV.D.DE217
-* otherReasonForStoppingArt 0..1 string "Other reason for stopping ART (specify)" "Client stopped ART because of other reason (specify)"
+* reasonArtStopped from HIV.D.DE217
+* otherReasonForStoppingArtSpecify 0..1 string "Other reason for stopping ART (specify)" "Client stopped ART because of other reason (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE224
 * treatmentFailure 0..* Coding "Treatment failure" "ART treatment failure"
   * ^code[+] = HIVConcepts#HIV.D.DE225
-  * treatmentFailure from HIV.D.DE225
+* treatmentFailure from HIV.D.DE225
 * generalCareActivitiesRecommended 0..* Coding "General care activities recommended" "General care activities to be performed during the care visit"
   * ^code[+] = HIVConcepts#HIV.D.DE229
-  * generalCareActivitiesRecommended from HIV.D.DE229
+* generalCareActivitiesRecommended from HIV.D.DE229
 * preventingAndTreatingCoinfections 0..* Coding "Preventing and treating coinfections" "Coinfection prevention and treatment activities performed during the care visit"
   * ^code[+] = HIVConcepts#HIV.D.DE247
-  * preventingAndTreatingCoinfections from HIV.D.DE247
-* riskFactorcomorbiditiesAndCoinfectionsSignsAndSymptoms 0..* Coding "Risk factors, comorbidities and coinfections signs and symptoms" "Signs and symptoms of opportunistic infections or other comorbidities experienced by client"
+* preventingAndTreatingCoinfections from HIV.D.DE247
+* riskFactorsComorbiditiesAndCoinfectionsSignsAndSymptoms 0..* Coding "Risk factors, comorbidities and coinfections signs and symptoms" "Signs and symptoms of opportunistic infections or other comorbidities experienced by client"
   * ^code[+] = HIVConcepts#HIV.D.DE259
-  * riskFactorcomorbiditiesAndCoinfectionsSignsAndSymptoms from HIV.D.DE259
-* other 0..1 string "Other (specify)" "Other comorbidities or coinfection signs or symptoms (specify)"
+* riskFactorsComorbiditiesAndCoinfectionsSignsAndSymptoms from HIV.D.DE259
+* otherRiskFactorsComorbiditiesAndCoinfectionsSignsAndSymptoms 0..1 string "Other (specify)" "Other comorbidities or coinfection signs or symptoms (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE288
 * whoHivClinicalStageConditionOrSymptom 0..* Coding "WHO HIV clinical stage condition or symptom" "New or recurrent clinical events used to categorize HIV disease severity based at baseline and follow up"
   * ^code[+] = HIVConcepts#HIV.D.DE289
-  * whoHivClinicalStageConditionOrSymptom from HIV.D.DE289
+* whoHivClinicalStageConditionOrSymptom from HIV.D.DE289
 * clinicalStageAtStartOfArt 0..1 Coding "Clinical stage at start of ART" "WHO clinical stage of client based on signs and symptoms at start of ART"
   * ^code[+] = HIVConcepts#HIV.D.DE358
-  * clinicalStageAtStartOfArt from HIV.D.DE358
+* clinicalStageAtStartOfArt from HIV.D.DE358
 * dateOfClinicalStatusChange 0..1 date "Date of clinical status change" "Date on which the client's WHO HIV clinical stage changed, including the date when the client's stage is first determined"
   * ^code[+] = HIVConcepts#HIV.D.DE363
 * cd4Count 0..1 integer "CD4 count" "CD4 cell count in cells/mm^3"
@@ -322,14 +322,14 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE369
 * reasonsForDelayedArtInitiation 0..* Coding "Reasons for delayed ART initiation" "Reason why ART was not initiated at diagnosis or within 7 days of diagnosis"
   * ^code[+] = HIVConcepts#HIV.D.DE370
-  * reasonsForDelayedArtInitiation from HIV.D.DE370
-* other 0..1 string "Other (specify)" "Client did not initiate ART at diagnosis or within 7 days of diagnosis because of other reason (specify)"
+* reasonsForDelayedArtInitiation from HIV.D.DE370
+* otherReasonsForDelayedArtInitiation 0..1 string "Other (specify)" "Client did not initiate ART at diagnosis or within 7 days of diagnosis because of other reason (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE381
-* artInitiatedWithin_7DaysOfDiagnosis 0..1 boolean "ART initiated within 7 days of diagnosis" "Client initiated ART within 7 days of diagnosis"
+* artInitiatedWithin7DaysOfDiagnosis 0..1 boolean "ART initiated within 7 days of diagnosis" "Client initiated ART within 7 days of diagnosis"
   * ^code[+] = HIVConcepts#HIV.D.DE382
 * timeToStartArt 0..1 Coding "Time to start ART" "Time from HIV diagnosis to when client started ART"
   * ^code[+] = HIVConcepts#HIV.D.DE383
-  * timeToStartArt from HIV.D.DE383
+* timeToStartArt from HIV.D.DE383
 * viralLoadTestResult 0..1 integer "Viral load test result" "Result from the viral load test in number of copies/mL"
   * ^code[+] = HIVConcepts#HIV.D.DE387
 * virallySuppressed 0..1 boolean "Virally suppressed" "The client is virally suppressed for HIV, based on the client's most recent viral load test result being less than 1000 copies/mL"
@@ -340,7 +340,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE390
 * reasonForHivViralLoadTest 0..1 Coding "Reason for HIV viral load test" "Whether the viral load is being tested for routine monitoring on a set schedule or for targeted monitoring for suspected treatment failure"
   * ^code[+] = HIVConcepts#HIV.D.DE391
-  * reasonForHivViralLoadTest from HIV.D.DE391
+* reasonForHivViralLoadTest from HIV.D.DE391
 * hepatitisBTestRequired 1..1 boolean "Hepatitis B test required" "Hepatitis B test is required"
   * ^code[+] = HIVConcepts#HIV.D.DE396
 * hepatitisCTestRecommended 1..1 boolean "Hepatitis C test recommended" "Hepatitis C test is recommended or should be considered"
@@ -349,7 +349,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE398
 * monitoringExaminations 0..* Coding "Monitoring examinations" "Name of examinations, test and results for any relevant investigations carried out for client"
   * ^code[+] = HIVConcepts#HIV.D.DE399
-  * monitoringExaminations from HIV.D.DE399
+* monitoringExaminations from HIV.D.DE399
 * dateOfScheduledMonitoringExamination 0..1 date "Date of scheduled monitoring examination" "Date of scheduled monitoring examination"
   * ^code[+] = HIVConcepts#HIV.D.DE413
 * hepatitisCTestOrdered 1..1 boolean "Hepatitis C test ordered" "Hepatitis C test has been ordered"
@@ -362,8 +362,8 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE417
 * reasonForArvDrugRegimenSubstitution 0..* Coding "Reason for ARV drug regimen substitution" "Reason why a substitution was made to the antiretroviral (ARV) drug regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE418
-  * reasonForArvDrugRegimenSubstitution from HIV.D.DE418
-* otherReasonForRegimenSubstitution 0..1 string "Other reason for regimen substitution (specify)" "A substitution was made for another reason (specify)"
+* reasonForArvDrugRegimenSubstitution from HIV.D.DE418
+* otherReasonForRegimenSubstitutionSpecify 0..1 string "Other reason for regimen substitution (specify)" "A substitution was made for another reason (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE426
 * switchToSecondLineArtRegimenRecommended 0..1 boolean "Switch to second-line ART regimen recommended" "A switch to second-line ART regimen is recommended"
   * ^code[+] = HIVConcepts#HIV.D.DE427
@@ -373,8 +373,8 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE429
 * reasonForRegimenSwitch 0..* Coding "Reason for regimen switch" "Reason why a switch to a second- or third-line regimen was made"
   * ^code[+] = HIVConcepts#HIV.D.DE430
-  * reasonForRegimenSwitch from HIV.D.DE430
-* other 0..1 string "Other (specify)" "A switch was made to the regimen for another reason (specify)"
+* reasonForRegimenSwitch from HIV.D.DE430
+* otherReasonForRegimenSwitch 0..1 string "Other (specify)" "A switch was made to the regimen for another reason (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE435
 * regimenSubstitutionRecommended 0..1 boolean "Regimen substitution recommended" "A drug substitution is recommended"
   * ^code[+] = HIVConcepts#HIV.D.DE436
@@ -394,15 +394,15 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE443
 * artRegimenPrescribed 0..1 Coding "ART regimen prescribed" "INCLUDE VALUE SETS OF REGIMENS"
   * ^code[+] = HIVConcepts#HIV.D.DE444
-  * artRegimenPrescribed from HIV.D.DE444
+* artRegimenPrescribed from HIV.D.DE444
 * antiretroviralToxicity 0..1 boolean "Antiretroviral toxicity" "Client is experiencing antiretroviral drug (ARV) toxicity"
   * ^code[+] = HIVConcepts#HIV.D.DE445
 * coinfectionStatusAtArtStart 0..* Coding "Coinfection status at ART start" "Clients status of coinfections at the time when ART was initiated"
   * ^code[+] = HIVConcepts#HIV.D.DE446
-  * coinfectionStatusAtArtStart from HIV.D.DE446
+* coinfectionStatusAtArtStart from HIV.D.DE446
 * pregnantAndBreastfeedingStatusAtArtStart 0..* Coding "Pregnant and breastfeeding status at ART start" "ART status of women to prevent mother-to-child transmission"
   * ^code[+] = HIVConcepts#HIV.D.DE449
-  * pregnantAndBreastfeedingStatusAtArtStart from HIV.D.DE449
+* pregnantAndBreastfeedingStatusAtArtStart from HIV.D.DE449
 * deliveryDateOfInfant 0..1 date "Delivery date of infant" "Date of delivery/birth of infant if breastfeeding at ART start"
   * ^code[+] = HIVConcepts#HIV.D.DE454
 * serodiscordantPartnerAtArtStart 0..1 boolean "Serodiscordant partner at ART start" "Client living with HIV was in an ongoing sexual relationship with an HIV-negative partner when ART was started"
@@ -411,7 +411,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE456
 * medicationsPrescribed 0..* Coding "Medications prescribed" "Name or regimen code of all other medications prescribed during the visit"
   * ^code[+] = HIVConcepts#HIV.D.DE457
-  * medicationsPrescribed from HIV.D.DE457
+* medicationsPrescribed from HIV.D.DE457
 * dateMedicationsPrescribed 0..1 date "Date medications prescribed" "Date the medications were prescribed"
   * ^code[+] = HIVConcepts#HIV.D.DE458
 * doseOfMedicationsPrescribed 0..1 integer "Dose of medications prescribed" "Number of doses (quantity taken at a single point in time) of drugs prescribed/dispensed"
@@ -420,7 +420,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE460
 * medicationsDispensed 0..* Coding "Medications dispensed" "Any other medications that were dispensed to client, including preventive treatment"
   * ^code[+] = HIVConcepts#HIV.D.DE461
-  * medicationsDispensed from HIV.D.DE461
+* medicationsDispensed from HIV.D.DE461
 * numberOfDaysOfMedicationsDispensed 0..1 integer "Number of days of medications dispensed" "Number of days supply of each medication or regimen dispensed during the visit"
   * ^code[+] = HIVConcepts#HIV.D.DE462
 * dosage 0..1 integer "Dosage" "Prescribed dosage of the medication"
@@ -431,49 +431,49 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE465
 * typeOfTreatmentLimitingToxicity 0..* Coding "Type of treatment-limiting toxicity" "Type of treatment-limiting toxicity experienced by client. Treatment-limiting toxicity is defined as a serious adverse drug reaction that results in drug discontinuation or substitution. In addition, any reaction that leads to treatment interruption or requires changing the drug or regimen because of an adverse drug reaction is also considered a serious adverse drug reaction."
   * ^code[+] = HIVConcepts#HIV.D.DE466
-  * typeOfTreatmentLimitingToxicity from HIV.D.DE466
-* unexpectedAdverseDrugReaction 0..1 string "Unexpected adverse drug reaction (specify)" "Specify the type of unexpected adverse drug reaction the client experienced"
+* typeOfTreatmentLimitingToxicity from HIV.D.DE466
+* unexpectedAdverseDrugReactionSpecify 0..1 string "Unexpected adverse drug reaction (specify)" "Specify the type of unexpected adverse drug reaction the client experienced"
   * ^code[+] = HIVConcepts#HIV.D.DE480
-* dat)OfSubstitutionWithinFirstLineRegimen 0..1 date "Date(s) of substitution within first-line regimen" "Date on which ARV drug regimen (one or more drugs) for client was changed within the first-line regimen (substitution)"
+* datesOfSubstitutionWithinFirstLineRegimen 0..1 date "Date(s) of substitution within first-line regimen" "Date on which ARV drug regimen (one or more drugs) for client was changed within the first-line regimen (substitution)"
   * ^code[+] = HIVConcepts#HIV.D.DE481
-* reaso)ForSubstitutionWithinFirstLineRegimen 0..* Coding "Reason(s) for substitution within first-line regimen" "Reason(s) why one ore more drugs in client's first-line ARV drug regimen was changed (substituted)"
+* reasonsForSubstitutionWithinFirstLineRegimen 0..* Coding "Reason(s) for substitution within first-line regimen" "Reason(s) why one ore more drugs in client's first-line ARV drug regimen was changed (substituted)"
   * ^code[+] = HIVConcepts#HIV.D.DE482
-  * reaso)ForSubstitutionWithinFirstLineRegimen from HIV.D.DE482
+* reasonsForSubstitutionWithinFirstLineRegimen from HIV.D.DE482
 * newAntiretroviralRegimenAfterSubstitutionWithinFirstLineRegimen 0..1 Coding "New antiretroviral regimen after substitution within first-line regimen" "New antiretroviral (ARV) drugs after client changed regimen within the first-line regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE483
-  * newAntiretroviralRegimenAfterSubstitutionWithinFirstLineRegimen from HIV.D.DE483
+* newAntiretroviralRegimenAfterSubstitutionWithinFirstLineRegimen from HIV.D.DE483
 * dateOfSwitchToSecondLineRegimen 0..1 date "Date of switch to second-line regimen" "Date client was changed from a first-line to second-line ARV drug regimen (switch)"
   * ^code[+] = HIVConcepts#HIV.D.DE484
 * newRegimenAfterSwitchToSecondLineRegimen 0..1 Coding "New regimen after switch to second-line regimen" "New ART regimen after switch to second-line ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE485
-  * newRegimenAfterSwitchToSecondLineRegimen from HIV.D.DE485
+* newRegimenAfterSwitchToSecondLineRegimen from HIV.D.DE485
 * reasonForSwitchToSecondLineRegimen 0..1 Coding "Reason for switch to second-line regimen" "Reason why client was switched from first- to second-line ARV drug regimen (see 'Reason for regimen switch' for levels)"
   * ^code[+] = HIVConcepts#HIV.D.DE486
-  * reasonForSwitchToSecondLineRegimen from HIV.D.DE486
-* dat)OfSubstitutionWithinSecondLineRegimen 0..1 date "Date(s) of substitution within second-line regimen" "Date on which ARV drug regimen for client was changed within the second-line regimen (substitution)"
+* reasonForSwitchToSecondLineRegimen from HIV.D.DE486
+* datesOfSubstitutionWithinSecondLineRegimen 0..1 date "Date(s) of substitution within second-line regimen" "Date on which ARV drug regimen for client was changed within the second-line regimen (substitution)"
   * ^code[+] = HIVConcepts#HIV.D.DE487
-* reaso)ForSubstitutionWithinSecondLineRegimen 0..1 Coding "Reason(s) for substitution within second-line regimen" "Reason(s) why client changed drug regimen (within the second-line)"
+* reasonsForSubstitutionWithinSecondLineRegimen 0..1 Coding "Reason(s) for substitution within second-line regimen" "Reason(s) why client changed drug regimen (within the second-line)"
   * ^code[+] = HIVConcepts#HIV.D.DE488
-  * reaso)ForSubstitutionWithinSecondLineRegimen from HIV.D.DE488
-* newRegime)AfterSubstitutionWithinSecondLineRegimen 0..1 Coding "New regimen(s) after substitution within second-line regimen" "New ARV drugs after client changed regimen within the second- line regimen"
+* reasonsForSubstitutionWithinSecondLineRegimen from HIV.D.DE488
+* newRegimensAfterSubstitutionWithinSecondLineRegimen 0..1 Coding "New regimen(s) after substitution within second-line regimen" "New ARV drugs after client changed regimen within the second- line regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE489
-  * newRegime)AfterSubstitutionWithinSecondLineRegimen from HIV.D.DE489
+* newRegimensAfterSubstitutionWithinSecondLineRegimen from HIV.D.DE489
 * dateOfSwitchToThirdLineRegimen 0..1 date "Date of switch to third-line regimen" "Date client was changed from a second- to third-line ARV drug regimen (switch)"
   * ^code[+] = HIVConcepts#HIV.D.DE490
 * newRegimenAfterSwitchToThirdLineRegimen 0..1 Coding "New regimen after switch to third-line regimen" "New ART regimen after switch to third-line ART regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE491
-  * newRegimenAfterSwitchToThirdLineRegimen from HIV.D.DE491
+* newRegimenAfterSwitchToThirdLineRegimen from HIV.D.DE491
 * reasonForSwitchToThirdLineRegimen 0..* Coding "Reason for switch to third-line regimen" "Reason why client was switched from second- to third-line ARV drug regimen (see 'Reason for regimen switch' for levels)"
   * ^code[+] = HIVConcepts#HIV.D.DE492
-  * reasonForSwitchToThirdLineRegimen from HIV.D.DE492
-* dat)OfSubstitutionWithinThirdLineRegimen 0..1 date "Date(s) of substitution within third-line regimen" "Date on which ARV drug regimen for client was changed within the third-line (substitution)"
+* reasonForSwitchToThirdLineRegimen from HIV.D.DE492
+* datesOfSubstitutionWithinThirdLineRegimen 0..1 date "Date(s) of substitution within third-line regimen" "Date on which ARV drug regimen for client was changed within the third-line (substitution)"
   * ^code[+] = HIVConcepts#HIV.D.DE493
-* reaso)ForSubstitutionWithinThirdLineRegimen 0..* Coding "Reason(s) for substitution within third-line regimen" "Reason(s) why client changed drug regimen (within the third-line)"
+* reasonsForSubstitutionWithinThirdLineRegimen 0..* Coding "Reason(s) for substitution within third-line regimen" "Reason(s) why client changed drug regimen (within the third-line)"
   * ^code[+] = HIVConcepts#HIV.D.DE494
-  * reaso)ForSubstitutionWithinThirdLineRegimen from HIV.D.DE494
-* newRegime)AfterSubstitutionWithinThirdLineRegimen 0..1 Coding "New regimen(s) after substitution within third-line regimen" "New ARV drugs after client changed regimen within the third-line regimen"
+* reasonsForSubstitutionWithinThirdLineRegimen from HIV.D.DE494
+* newRegimensAfterSubstitutionWithinThirdLineRegimen 0..1 Coding "New regimen(s) after substitution within third-line regimen" "New ARV drugs after client changed regimen within the third-line regimen"
   * ^code[+] = HIVConcepts#HIV.D.DE495
-  * newRegime)AfterSubstitutionWithinThirdLineRegimen from HIV.D.DE495
+* newRegimensAfterSubstitutionWithinThirdLineRegimen from HIV.D.DE495
 * enhancedAdherenceCounsellingProvided 0..1 boolean "Enhanced adherence counselling provided" "Enhanced adherence counselling was provided to the client during the visit"
   * ^code[+] = HIVConcepts#HIV.D.DE496
 * firstEnhancedAdherenceCounsellingSessionCompleted 0..1 boolean "First enhanced adherence counselling session completed" "A first enhanced adherence counselling was provided to the client during the visit"
@@ -504,7 +504,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE509
 * syphilisCounsellingAndTreatment 0..1 boolean "Syphilis counselling and treatment" "Whether counselling and treatment was provided to a client who has been diagnosed with syphilis"
   * ^code[+] = HIVConcepts#HIV.D.DE510
-* syphilisCounsellintreatmentAndFurtherTesting 0..1 boolean "Syphilis counselling, treatment and further testing" "Whether counselling and treatment was provided to a client who has been diagnosed with syphilis. Additional testing (RPR test) recommended."
+* syphilisCounsellingTreatmentAndFurtherTesting 0..1 boolean "Syphilis counselling, treatment and further testing" "Whether counselling and treatment was provided to a client who has been diagnosed with syphilis. Additional testing (RPR test) recommended."
   * ^code[+] = HIVConcepts#HIV.D.DE511
 * acceptedPartnerServices 0..1 boolean "Accepted partner services" "Client accepted offer for partner services"
   * ^code[+] = HIVConcepts#HIV.D.DE512
@@ -512,7 +512,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE513
 * hivStatusOfFamilyMember 0..1 Coding "HIV status of family member" "HIV status of each family member at time of patient's enrolment, including partner (for mothers)"
   * ^code[+] = HIVConcepts#HIV.D.DE514
-  * hivStatusOfFamilyMember from HIV.D.DE514
+* hivStatusOfFamilyMember from HIV.D.DE514
 * uniqueIdOfFamilyMember 0..1 Identifier "Unique ID of family member" "Unique ID number of each family member if enrolled in HIV care according to national guidelines (see unique ID number)"
   * ^code[+] = HIVConcepts#HIV.D.DE515
 * dateOfDeathOfFamilyMember 0..1 date "Date of death of family member" "Date of death for each family member as appropriate"
@@ -523,50 +523,50 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE518
 * otherSupportServices 0..* Coding "Other support services" "Offer or refer for other support services"
   * ^code[+] = HIVConcepts#HIV.D.DE519
-  * otherSupportServices from HIV.D.DE519
+* otherSupportServices from HIV.D.DE519
 * dateTimeOfFollowUpAppointment 0..1 dateTime "Date/time of follow-up appointment" "Date the client is to return for monitoring, re-supply or any other reason"
   * ^code[+] = HIVConcepts#HIV.D.DE524
 * typeOfFollowUpAppointment 0..* Coding "Type of follow-up appointment" "Whether the visit will be clinical only, ARV drug pick-up or other. Client may have multiple follow-ups scheduled."
   * ^code[+] = HIVConcepts#HIV.D.DE525
-  * typeOfFollowUpAppointment from HIV.D.DE525
-* other 0..1 string "Other (specify)" "Other reason for the follow-up appointment (specify)"
+* typeOfFollowUpAppointment from HIV.D.DE525
+* otherTypeOfFollowUpAppointment 0..1 string "Other (specify)" "Other reason for the follow-up appointment (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE530
 * followUpTestRecommendedDate 0..1 date "Follow-up test recommended date" "A test or screening recommended for the client's care plan at a future date"
   * ^code[+] = HIVConcepts#HIV.D.DE531
 * reasonBloodPressureReadingNotDone 0..1 Coding "Reason blood pressure reading not done" "Reason why test was not performed"
   * ^code[+] = HIVConcepts#HIV.D.DE532
-  * reasonBloodPressureReadingNotDone from HIV.D.DE532
-* other 0..1 string "Other (specify)" "Other reason blood pressure can not be taken (specify)"
+* reasonBloodPressureReadingNotDone from HIV.D.DE532
+* otherReasonBloodPressureReadingNotDone 0..1 string "Other (specify)" "Other reason blood pressure can not be taken (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE536
 * currentMedications 1..* Coding "Current medications" "List of all of the medications the client is currently taking"
   * ^code[+] = HIVConcepts#HIV.D.DE537
-  * currentMedications from HIV.D.DE537
-* otherMedications 0..1 string "Other medications (specify)" "Other medications or supplements that are not listed above (specify)"
+* currentMedications from HIV.D.DE537
+* otherMedicationsSpecify 0..1 string "Other medications (specify)" "Other medications or supplements that are not listed above (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE559
 * allergies 1..* Coding "Allergies" "Does the client have any allergies?"
   * ^code[+] = HIVConcepts#HIV.D.DE560
-  * allergies from HIV.D.DE560
-* otherAllergies 0..1 string "Other allergies (specify)" "Client has other allergies not listed here (specify)"
+* allergies from HIV.D.DE560
+* otherAllergiesSpecify 0..1 string "Other allergies (specify)" "Client has other allergies not listed here (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE568
 * familyPlanningMethodUsed 0..1 Coding "Family planning method used" "Method the client reports currently using at intake"
   * ^code[+] = HIVConcepts#HIV.D.DE569
-  * familyPlanningMethodUsed from HIV.D.DE569
+* familyPlanningMethodUsed from HIV.D.DE569
 * medicationStatus 0..1 Coding "Medication status" "Current state of the client's taking of the medication"
   * ^code[+] = HIVConcepts#HIV.D.DE593
-  * medicationStatus from HIV.D.DE593
+* medicationStatus from HIV.D.DE593
 * hepatitisBNegativeCounsellingConducted 0..1 boolean "Hepatitis B negative counselling conducted" "Hepatitis B negative counselling conducted"
   * ^code[+] = HIVConcepts#HIV.D.DE602
 * vaccineBrand 0..1 Coding "Vaccine brand" "The brand or trade name used to refer to the vaccine received"
   * ^code[+] = HIVConcepts#HIV.D.DE603
-  * vaccineBrand from HIV.D.DE603
+* vaccineBrand from HIV.D.DE603
 * vaccineType 0..1 Coding "Vaccine type" "Type of vaccine received (such as IPV, OPV)"
   * ^code[+] = HIVConcepts#HIV.D.DE604
-  * vaccineType from HIV.D.DE604
+* vaccineType from HIV.D.DE604
 * dateAndTimeOfVaccination 0..1 dateTime "Date and time of vaccination" "Represents the visit/encounter date, which is the date and time when the vaccine was administered to the client"
   * ^code[+] = HIVConcepts#HIV.D.DE605
 * vaccinationLocation 0..1 Coding "Vaccination location" "The service delivery location where the vaccine adminstration occurred"
   * ^code[+] = HIVConcepts#HIV.D.DE606
-  * vaccinationLocation from HIV.D.DE606
+* vaccinationLocation from HIV.D.DE606
 * doseNumber 0..1 integer "Dose number" "Vaccine dose number within series"
   * ^code[+] = HIVConcepts#HIV.D.DE607
 * doseQuantity 0..1 integer "Dose quantity" "The quantity of vaccine product that was administered"
@@ -575,11 +575,11 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE609
 * diseaseTargeted 0..* Coding "Disease targeted" "Vaccine preventable disease being targeted by vaccine administered"
   * ^code[+] = HIVConcepts#HIV.D.DE610
-  * diseaseTargeted from HIV.D.DE610
+* diseaseTargeted from HIV.D.DE610
 * reasonImmunizationWasNotProvided 1..1 Coding "Reason immunization was not provided" "Reason the vaccine dose was not given"
   * ^code[+] = HIVConcepts#HIV.D.DE636
-  * reasonImmunizationWasNotProvided from HIV.D.DE636
-* otherReasonImmunizationNotProvided 0..1 string "Other reason immunization not provided (specify)" "Other reason why the immunization was not provided (specify)"
+* reasonImmunizationWasNotProvided from HIV.D.DE636
+* otherReasonImmunizationNotProvidedSpecify 0..1 string "Other reason immunization not provided (specify)" "Other reason why the immunization was not provided (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE642
 * malariaProphylaxis 1..1 boolean "Malaria prophylaxis" "Whether malaria prophylaxis was given"
   * ^code[+] = HIVConcepts#HIV.D.DE643
@@ -589,10 +589,10 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE645
 * reasonMalariaProphylaxisNotProvided 0..* Coding "Reason malaria prophylaxis not provided" "Reason why the treatment was not given"
   * ^code[+] = HIVConcepts#HIV.D.DE646
-  * reasonMalariaProphylaxisNotProvided from HIV.D.DE646
-* otherReasonNotProvided 0..1 string "Other reason not provided (specify)" "Other reason why the prophylaxis was not provided"
+* reasonMalariaProphylaxisNotProvided from HIV.D.DE646
+* otherReasonNotProvidedSpecify 0..1 string "Other reason not provided (specify)" "Other reason why the prophylaxis was not provided"
   * ^code[+] = HIVConcepts#HIV.D.DE651
-* >28DaysSinceLastMissedAppointment 0..1 boolean ">28 days since last missed appointment" "More than 28 days have passed since client's last missed appointment"
+* moreThan28DaysSinceLastMissedAppointment 0..1 boolean ">28 days since last missed appointment" "More than 28 days have passed since client's last missed appointment"
   * ^code[+] = HIVConcepts#HIV.D.DE652
 * aidsRelatedDeath 0..1 boolean "AIDS-related death" "Death of client was AIDS-related"
   * ^code[+] = HIVConcepts#HIV.D.DE653
@@ -606,57 +606,57 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE657
 * cervicalCancerPrimaryScreeningTestType 0..1 Coding "Cervical cancer primary screening test type" "Type of cervical cancer screening test used in primary screening"
   * ^code[+] = HIVConcepts#HIV.D.DE658
-  * cervicalCancerPrimaryScreeningTestType from HIV.D.DE658
-* other 0..1 string "Other (specify)" "Screened for cervical cancer using other method (specify)"
+* cervicalCancerPrimaryScreeningTestType from HIV.D.DE658
+* otherCervicalCancerPrimaryScreeningTestType 0..1 string "Other (specify)" "Screened for cervical cancer using other method (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE663
 * hpvDnaCervicalCancerScreeningTestResult 0..1 Coding "HPV-DNA cervical cancer screening test result" "HPV-DNA cervical cancer screening test result"
   * ^code[+] = HIVConcepts#HIV.D.DE664
-  * hpvDnaCervicalCancerScreeningTestResult from HIV.D.DE664
+* hpvDnaCervicalCancerScreeningTestResult from HIV.D.DE664
 * viaCervicalCancerScreeningTestResult 0..1 Coding "VIA cervical cancer screening test result" "Screening test result for VIA"
   * ^code[+] = HIVConcepts#HIV.D.DE668
-  * viaCervicalCancerScreeningTestResult from HIV.D.DE668
+* viaCervicalCancerScreeningTestResult from HIV.D.DE668
 * cervicalCytologyScreeningTestResult 0..1 Coding "Cervical cytology screening test result" "Screening result for cervical cytology"
   * ^code[+] = HIVConcepts#HIV.D.DE673
-  * cervicalCytologyScreeningTestResult from HIV.D.DE673
+* cervicalCytologyScreeningTestResult from HIV.D.DE673
 * cervicalCancerTriageTestDate 0..1 dateTime "Cervical cancer triage test date" "Date of triage test for cervical cancer"
   * ^code[+] = HIVConcepts#HIV.D.DE680
 * cervicalCancerTriageTestType 0..1 Coding "Cervical cancer triage test type" "Type of triage test for cervical cancer"
   * ^code[+] = HIVConcepts#HIV.D.DE681
-  * cervicalCancerTriageTestType from HIV.D.DE681
-* other 0..1 string "Other (specify)" "Triage test for cervical cancer using another test (specify)"
+* cervicalCancerTriageTestType from HIV.D.DE681
+* otherCervicalCancerTriageTestType 0..1 string "Other (specify)" "Triage test for cervical cancer using another test (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE687
-* hpv16_18TestResult 0..1 Coding "HPV16/18 test result" "Test result from HPV16/18 test"
+* hpv1618TestResult 0..1 Coding "HPV16/18 test result" "Test result from HPV16/18 test"
   * ^code[+] = HIVConcepts#HIV.D.DE688
-  * hpv16_18TestResult from HIV.D.DE688
+* hpv1618TestResult from HIV.D.DE688
 * cervicalCancerColposcopyResult 0..1 Coding "Cervical cancer colposcopy result" "Result of cervical cancer colposcopy"
   * ^code[+] = HIVConcepts#HIV.D.DE691
-  * cervicalCancerColposcopyResult from HIV.D.DE691
+* cervicalCancerColposcopyResult from HIV.D.DE691
 * cervicalCancerHistopathologyResult 0..1 Coding "Cervical cancer histopathology result" "Result of cervical cancer histopathology"
   * ^code[+] = HIVConcepts#HIV.D.DE697
-  * cervicalCancerHistopathologyResult from HIV.D.DE697
+* cervicalCancerHistopathologyResult from HIV.D.DE697
 * dateOfAdditionalCervicalCancerTriageTest 0..1 string "Date of additional cervical cancer triage test" "Date of tertiary cervical cancer screening test"
   * ^code[+] = HIVConcepts#HIV.D.DE702
-* additionalCervicalCancerTriageTestType 0..1 string "Additional cervical cancer triage test type (specify)" "Additional cervical cancer triage test type (specify)"
+* additionalCervicalCancerTriageTestTypeSpecify 0..1 string "Additional cervical cancer triage test type (specify)" "Additional cervical cancer triage test type (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE703
-* additionalCervicalCancerTriageTestResult 0..1 string "Additional cervical cancer triage test result (specify)" "Additional cervical cancer triage test result (specify)"
+* additionalCervicalCancerTriageTestResultSpecify 0..1 string "Additional cervical cancer triage test result (specify)" "Additional cervical cancer triage test result (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE704
-* dateOfDiagnosisOfCervicalPrecancerLesionsOrInvasiveCervicalCancer 0..1 dateTime "Date of diagnosis of cervical precancer lesions or invasive cervical cancer" "Date of diagnosis of cervical precancer lesions or invasive cervical cancer"
+* dateOfDiagnosisOfCervicalPrecancerLesionsOrInvasiveCervical 0..1 dateTime "Date of diagnosis of cervical precancer lesions or invasive cervical cancer" "Date of diagnosis of cervical precancer lesions or invasive cervical cancer"
   * ^code[+] = HIVConcepts#HIV.D.DE705
 * cervicalCancerScreeningOutcome 0..1 Coding "Cervical cancer screening outcome" "Client's screening outcome for cervical cancer"
   * ^code[+] = HIVConcepts#HIV.D.DE706
-  * cervicalCancerScreeningOutcome from HIV.D.DE706
+* cervicalCancerScreeningOutcome from HIV.D.DE706
 * cervicalCancerDiagnosis 0..1 Coding "Cervical cancer diagnosis" "Type of cervical cancer diagnosis"
   * ^code[+] = HIVConcepts#HIV.D.DE709
-  * cervicalCancerDiagnosis from HIV.D.DE709
+* cervicalCancerDiagnosis from HIV.D.DE709
 * cervicalCancerStageAtDiagnosis 0..1 Coding "Cervical cancer stage at diagnosis" "Cervical cancer stage at diagnosis of cervical cancer"
   * ^code[+] = HIVConcepts#HIV.D.DE712
-  * cervicalCancerStageAtDiagnosis from HIV.D.DE712
+* cervicalCancerStageAtDiagnosis from HIV.D.DE712
 * dateOfTreatmentForCervicalPrecancerLesions 0..1 dateTime "Date of treatment for cervical precancer lesions" "Date of treatment for cervical precancer lesions"
   * ^code[+] = HIVConcepts#HIV.D.DE718
 * treatmentMethodForCervicalPrecancerLesions 0..* Coding "Treatment method for cervical precancer lesions" "Treatment method for cervical precancer lesions"
   * ^code[+] = HIVConcepts#HIV.D.DE719
-  * treatmentMethodForCervicalPrecancerLesions from HIV.D.DE719
-* other 0..1 string "Other (specify)" "Treatment for cervical precancer lesions is not listed (specify)"
+* treatmentMethodForCervicalPrecancerLesions from HIV.D.DE719
+* otherTreatmentMethodForCervicalPrecancerLesions 0..1 string "Other (specify)" "Treatment for cervical precancer lesions is not listed (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE727
 * dateOfFollowUpForTreatmentForCervicalPrecancerLesions 0..1 dateTime "Date of follow-up for treatment for cervical precancer lesions" "Date of follow-up for treatment for cervical precancer lesions"
   * ^code[+] = HIVConcepts#HIV.D.DE728
@@ -666,14 +666,14 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE730
 * invasiveCervicalCancerTreatmentMethod 1..* Coding "Invasive cervical cancer treatment method" "Invasive cervical cancer treatment method"
   * ^code[+] = HIVConcepts#HIV.D.DE731
-  * invasiveCervicalCancerTreatmentMethod from HIV.D.DE731
-* other 0..1 string "Other (specify)" "Invasive cervical cancer treatment method is a not in list (specify)"
+* invasiveCervicalCancerTreatmentMethod from HIV.D.DE731
+* otherInvasiveCervicalCancerTreatmentMethod 0..1 string "Other (specify)" "Invasive cervical cancer treatment method is a not in list (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE740
 * treatmentOutcome 0..1 string "Treatment outcome" "Treatment outcome from cervical pre-cancerous lesion treatment or invasive cancer treatment (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE741
 * secondaryOtherCancersDiagnosed 0..1 string "Secondary/other cancers diagnosed" "Secondary and other cancers that client is diagnosed with (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE742
-* cancersAtOtherSites 0..1 string "Cancers at other sites (HPV- and non-HPV related)" "Cancers at other sites that client has (specify)"
+* cancersAtOtherSitesHpvAndNonHpvRelated 0..1 string "Cancers at other sites (HPV- and non-HPV related)" "Cancers at other sites that client has (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE743
 * dateOfDeath 0..1 dateTime "Date of death" "If deceased, the date that the client died"
   * ^code[+] = HIVConcepts#HIV.D.DE744
@@ -681,10 +681,10 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE745
 * entryPointForFacilityLevelTesting 0..1 Coding "Entry point for facility-level testing" "Specific point where testing is happening at a facility"
   * ^code[+] = HIVConcepts#HIV.D.DE746
-  * entryPointForFacilityLevelTesting from HIV.D.DE746
+* entryPointForFacilityLevelTesting from HIV.D.DE746
 * offerOtherClinicalServices 0..* Coding "Offer other clinical services" "Other clinical services offered or referrals given to the client"
   * ^code[+] = HIVConcepts#HIV.D.DE753
-  * offerOtherClinicalServices from HIV.D.DE753
+* offerOtherClinicalServices from HIV.D.DE753
 * eligibleForDsdArt 0..1 boolean "Eligible for DSD ART" "Client is eligible for differentiated service delivery (DSD) for ART"
   * ^code[+] = HIVConcepts#HIV.D.DE760
 * dateDsdArtEligibilityAssessed 0..1 date "Date DSD ART eligibility assessed" "Date client was assessed for eligibility for differentiated service delivery (DSD) for ART"
@@ -693,10 +693,10 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE762
 * dsdArtStartDate 0..1 date "DSD ART start date" "Date client started on differentiated service delivery (DSD) for ART"
   * ^code[+] = HIVConcepts#HIV.D.DE763
-* dsdArtModel 0..* Coding "DSD ART model(s)" "Type of DSD ART model client is enrolled in (country-specific)"
+* dsdArtModels 0..* Coding "DSD ART model(s)" "Type of DSD ART model client is enrolled in (country-specific)"
   * ^code[+] = HIVConcepts#HIV.D.DE764
-  * dsdArtModel from HIV.D.DE764
-* otherDsdArtModel 0..1 string "Other DSD ART model (specify)" "Client is enrolled in another DSD ART model (specify)"
+* dsdArtModels from HIV.D.DE764
+* otherDsdArtModelSpecify 0..1 string "Other DSD ART model (specify)" "Client is enrolled in another DSD ART model (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE771
 * partnerTestingOffered 0..1 boolean "Partner testing offered" "Whether client was offered partner testing"
   * ^code[+] = HIVConcepts#HIV.D.DE772
@@ -712,8 +712,8 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE777
 * syndromeStiDiagnosed 0..* Coding "Syndrome/STI diagnosed" "Syndrome or STI for which client is diagnosed"
   * ^code[+] = HIVConcepts#HIV.D.DE778
-  * syndromeStiDiagnosed from HIV.D.DE778
-* other 0..1 string "Other (specify)" "Other syndrome/STI diagnosed (specify)"
+* syndromeStiDiagnosed from HIV.D.DE778
+* otherSyndromeStiDiagnosed 0..1 string "Other (specify)" "Other syndrome/STI diagnosed (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE786
 * anyStiSyndromeDiagnosed 0..1 boolean "Any STI syndrome diagnosed" "Was the client diagnosed with any of the five STI syndromes during this visit?"
   * ^code[+] = HIVConcepts#HIV.D.DE787
@@ -721,88 +721,88 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE788
 * stiTestedFor 0..* Coding "STI tested for" "STI for which the client was tested"
   * ^code[+] = HIVConcepts#HIV.D.DE789
-  * stiTestedFor from HIV.D.DE789
-* other 0..1 string "Other (specify)" "Client tested for other STI (specify)"
+* stiTestedFor from HIV.D.DE789
+* otherStiTestedFor 0..1 string "Other (specify)" "Client tested for other STI (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE800
 * syphilisTestDate 0..1 dateTime "Syphilis test date" "Date of syphilis test"
   * ^code[+] = HIVConcepts#HIV.D.DE801
 * syphilisTestResult 0..1 Coding "Syphilis test result" "Result from syphilis test"
   * ^code[+] = HIVConcepts#HIV.D.DE802
-  * syphilisTestResult from HIV.D.DE802
+* syphilisTestResult from HIV.D.DE802
 * syphilisTreatmentStartDate 0..1 dateTime "Syphilis treatment start date" "Date of initiation of syphilis treatment"
   * ^code[+] = HIVConcepts#HIV.D.DE806
 * gonorrhoeaTestDate 0..1 dateTime "Gonorrhoea test date" "Date of Gonorrhoea test"
   * ^code[+] = HIVConcepts#HIV.D.DE807
 * gonorrhoeaTestResult 0..1 Coding "Gonorrhoea test result" "Result from Gonorrhoea test"
   * ^code[+] = HIVConcepts#HIV.D.DE808
-  * gonorrhoeaTestResult from HIV.D.DE808
+* gonorrhoeaTestResult from HIV.D.DE808
 * gonorrhoeaTreatmentStartDate 0..1 dateTime "Gonorrhoea treatment start date" "Date of initiation of Gonorrhoea treatment"
   * ^code[+] = HIVConcepts#HIV.D.DE812
 * typeOfSpecimen 0..* Coding "Type of specimen" "Type of specimen to be collected"
   * ^code[+] = HIVConcepts#HIV.D.DE813
-  * typeOfSpecimen from HIV.D.DE813
-* otherTypeOfSpecimen 0..1 string "Other type of specimen (specify)" "Other specimen type to be collected (specify)"
+* typeOfSpecimen from HIV.D.DE813
+* otherTypeOfSpecimenSpecify 0..1 string "Other type of specimen (specify)" "Other specimen type to be collected (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE820
 * syphilisTestType 0..* Coding "Syphilis test type" "Type of diagnostic test used for syphilis (Treponema pallidum)"
   * ^code[+] = HIVConcepts#HIV.D.DE821
-  * syphilisTestType from HIV.D.DE821
-* otherSyphilisTestType 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
+* syphilisTestType from HIV.D.DE821
+* otherSyphilisTestTypeSpecify 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE827
 * neisseriaGonorrhoeaeTestType 0..1 Coding "Neisseria gonorrhoeae test type" "Type of diagnostic test used for Neisseria gonorrhoeae"
   * ^code[+] = HIVConcepts#HIV.D.DE828
-  * neisseriaGonorrhoeaeTestType from HIV.D.DE828
-* other 0..1 string "Other (specify)" "Other type of test used (specify)"
+* neisseriaGonorrhoeaeTestType from HIV.D.DE828
+* otherNeisseriaGonorrhoeaeTestType 0..1 string "Other (specify)" "Other type of test used (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE834
-* pocTestForNeisseriaGonorrhoeae 0..1 string "POC Test for Neisseria gonorrhoeae (specify)" "Point-of-care (POC) test used for Neisseria gonorrhoeae (specify)"
+* pocTestForNeisseriaGonorrhoeaeSpecify 0..1 string "POC Test for Neisseria gonorrhoeae (specify)" "Point-of-care (POC) test used for Neisseria gonorrhoeae (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE835
 * chlamydiaTrachomatisTestType 0..1 Coding "Chlamydia trachomatis test type" "Type of diagnostic test used for Chlamydia trachomatis"
   * ^code[+] = HIVConcepts#HIV.D.DE836
-  * chlamydiaTrachomatisTestType from HIV.D.DE836
-* otherTestForChlamydia 0..1 string "Other test for Chlamydia (specify)" "Other type of test used for Chlaymdia (specify)"
+* chlamydiaTrachomatisTestType from HIV.D.DE836
+* otherTestForChlamydiaSpecify 0..1 string "Other test for Chlamydia (specify)" "Other type of test used for Chlaymdia (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE843
-* pocTestTypeForChlamydiaTest 0..1 string "POC Test type for Chlamydia test (specify)" "Point-of-care (POC) test used for Chlamydia (specify)"
+* pocTestTypeForChlamydiaTestSpecify 0..1 string "POC Test type for Chlamydia test (specify)" "Point-of-care (POC) test used for Chlamydia (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE844
 * trichomonasVaginalisTestType 0..1 Coding "Trichomonas vaginalis test type" "Type of diagnostic test used for Trichomonas vaginalis"
   * ^code[+] = HIVConcepts#HIV.D.DE845
-  * trichomonasVaginalisTestType from HIV.D.DE845
-* other 0..1 string "Other (specify)" "Other type of test used (specify)"
+* trichomonasVaginalisTestType from HIV.D.DE845
+* otherTrichomonasVaginalisTestType 0..1 string "Other (specify)" "Other type of test used (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE851
-* pocTestTypeForTrichomonasVaginalisTest 0..1 string "POC Test type for Trichomonas vaginalis test (specify)" "Point-of-care (POC) test used (specify)"
+* pocTestTypeForTrichomonasVaginalisTestSpecify 0..1 string "POC Test type for Trichomonas vaginalis test (specify)" "Point-of-care (POC) test used (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE852
-* herpesSimplexVirusstestType 0..1 Coding "Herpes simplex virus (HSV) test type" "Type of diagnostic test used for Herpes simplex virus (HSV)"
+* herpesSimplexVirusHsvTestType 0..1 Coding "Herpes simplex virus (HSV) test type" "Type of diagnostic test used for Herpes simplex virus (HSV)"
   * ^code[+] = HIVConcepts#HIV.D.DE853
-  * herpesSimplexVirusstestType from HIV.D.DE853
-* other 0..1 string "Other (specify)" "Other type of test used for Herpes simplex virus (HSV) test (specify)"
+* herpesSimplexVirusHsvTestType from HIV.D.DE853
+* otherHerpesSimplexVirusHsvTestType 0..1 string "Other (specify)" "Other type of test used for Herpes simplex virus (HSV) test (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE857
 * mycoplasmaGenitaliumTestType 0..1 Coding "Mycoplasma genitalium test type" "Type of diagnostic test used for Mycoplasma genitalium"
   * ^code[+] = HIVConcepts#HIV.D.DE858
-  * mycoplasmaGenitaliumTestType from HIV.D.DE858
-* other 0..1 string "Other (specify)" "Other type of test used for Mycoplasma genitalium test (specify)"
+* mycoplasmaGenitaliumTestType from HIV.D.DE858
+* otherMycoplasmaGenitaliumTestType 0..1 string "Other (specify)" "Other type of test used for Mycoplasma genitalium test (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE862
-* testTypeForOtherStiTestedFor 0..1 string "Test type for other STI tested for (specify)" "Test type used for the other specified STI"
+* testTypeForOtherStiTestedForSpecify 0..1 string "Test type for other STI tested for (specify)" "Test type used for the other specified STI"
   * ^code[+] = HIVConcepts#HIV.D.DE863
 * stiTestResult 0..1 Coding "STI test result" "Result from STI test"
   * ^code[+] = HIVConcepts#HIV.D.DE864
-  * stiTestResult from HIV.D.DE864
+* stiTestResult from HIV.D.DE864
 * dateOfStiConfirmatoryTest 0..1 dateTime "Date of STI confirmatory test" "Date of STI confirmatory test"
   * ^code[+] = HIVConcepts#HIV.D.DE868
 * confirmatorySyphilisTestType 0..* Coding "Confirmatory syphilis test type" "Type of test ued for confirmatory syphilis test"
   * ^code[+] = HIVConcepts#HIV.D.DE869
-  * confirmatorySyphilisTestType from HIV.D.DE869
-* other 0..1 string "Other (specify)" "Other test used for confirmatory syphilis test (specify)"
+* confirmatorySyphilisTestType from HIV.D.DE869
+* otherConfirmatorySyphilisTestType 0..1 string "Other (specify)" "Other test used for confirmatory syphilis test (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE875
-* confirmatoryTestTypeForOtherSti 0..1 string "Confirmatory test type for other STI (specify)" "Confirmatory test type for other STI"
+* confirmatoryTestTypeForOtherStiSpecify 0..1 string "Confirmatory test type for other STI (specify)" "Confirmatory test type for other STI"
   * ^code[+] = HIVConcepts#HIV.D.DE876
 * confirmatoryStiTestResult 0..1 Coding "Confirmatory STI test result" "Result from confirmatory STI test"
   * ^code[+] = HIVConcepts#HIV.D.DE877
-  * confirmatoryStiTestResult from HIV.D.DE877
+* confirmatoryStiTestResult from HIV.D.DE877
 * dateStiTreatmentPrescribed 0..1 dateTime "Date STI treatment prescribed" "Date STI treatment was prescribed to the client"
   * ^code[+] = HIVConcepts#HIV.D.DE881
 * dateStiTreatmentDispensed 0..1 dateTime "Date STI treatment dispensed" "Date STI treatment dispensed to the client"
   * ^code[+] = HIVConcepts#HIV.D.DE882
-* stiTreatmentDispensed 0..1 string "STI treatment dispensed (specify)" "STI treatment dispensed to the client"
+* stiTreatmentDispensedSpecify 0..1 string "STI treatment dispensed (specify)" "STI treatment dispensed to the client"
   * ^code[+] = HIVConcepts#HIV.D.DE883
-* midUpperArmCircumference 0..1 integer "Mid-upper arm circumference (MUAC)" "Client's mid-upper arm circumference (MUAC)"
+* midUpperArmCircumferenceMuac 0..1 integer "Mid-upper arm circumference (MUAC)" "Client's mid-upper arm circumference (MUAC)"
   * ^code[+] = HIVConcepts#HIV.D.DE884
 * dateOfStartOfFluconazoleProphylaxis 0..1 date "Date of start of fluconazole prophylaxis" "Date of client's start of fluconazole prophylaxis"
   * ^code[+] = HIVConcepts#HIV.D.DE885
@@ -822,20 +822,20 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE892
 * stagingOfLiverDisease 0..1 Coding "Staging of liver disease" "Staging of liver disease in client"
   * ^code[+] = HIVConcepts#HIV.D.DE893
-  * stagingOfLiverDisease from HIV.D.DE893
+* stagingOfLiverDisease from HIV.D.DE893
 * advancedHivDisease 0..1 boolean "Advanced HIV disease" "Client has Advanced HIV disease (AHD)"
   * ^code[+] = HIVConcepts#HIV.D.DE896
 * whoFunctionalStatus 0..1 Coding "WHO functional status" "Functional status of people with advanced HIV disease"
   * ^code[+] = HIVConcepts#HIV.D.DE897
-  * whoFunctionalStatus from HIV.D.DE897
+* whoFunctionalStatus from HIV.D.DE897
 * tailoredAdherenceCounsellingForAdvancedHivDisease 0..1 boolean "Tailored adherence counselling for advanced HIV disease" "Client provided with tailored adherence counselling for advanced HIV disease"
   * ^code[+] = HIVConcepts#HIV.D.DE901
-* dat)OfTracingInterventions 0..1 date "Date(s) of tracing interventions" "Date tracing interventions to support reengagement into HIV care conducted"
+* datesOfTracingInterventions 0..1 date "Date(s) of tracing interventions" "Date tracing interventions to support reengagement into HIV care conducted"
   * ^code[+] = HIVConcepts#HIV.D.DE902
 * medicationDrug 0..* Coding "Medication/drug" "Current or considered medication/drug, for the purpose of determining drug interactions"
   * ^code[+] = HIVConcepts#HIV.D.DE903
-  * medicationDrug from HIV.D.DE903
-* other 0..1 string "Other (specify)" "Other medication currently being taken by, or considered for, client (specify)"
+* medicationDrug from HIV.D.DE903
+* otherMedicationDrug 0..1 string "Other (specify)" "Other medication currently being taken by, or considered for, client (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE932
 * medicationChangeRecommended 0..1 boolean "Medication change recommended" "A medication change is recommended for the client based upon current or considered medications"
   * ^code[+] = HIVConcepts#HIV.D.DE933

--- a/input/fsh/models/HIVDHIVTB.fsh
+++ b/input/fsh/models/HIVDHIVTB.fsh
@@ -1,9 +1,9 @@
-Invariant:    HIV-D-1
+Invariant:    HIV-D-17
 Description:  "DateTime ≤ Current DateTime"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-D-2
+Invariant:    HIV-D-18
 Description:  "Required if 'TB diagnosis result'='Diagnosed TB'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
@@ -20,52 +20,52 @@ Description: "This tab describes the data that may be collected during care and 
 
 * whoHivClinicalStageConditionOrSymptom 0..* Coding "WHO HIV clinical stage condition or symptom" "New or recurrent clinical events used to categorize HIV disease severity based at baseline and follow up"
   * ^code[+] = HIVConcepts#HIV.D.DE934
-  * whoHivClinicalStageConditionOrSymptom from HIV.D.DE934
+* whoHivClinicalStageConditionOrSymptom from HIV.D.DE934
 * tbDisease 0..1 boolean "TB disease" "Whether the client has tuberculosis (TB) disease. Sometimes known as active TB"
   * ^code[+] = HIVConcepts#HIV.D.DE938
 * tbDiagnosisResult 0..1 Coding "TB diagnosis result" "Final result of the TB investigation (bacteriological and/or clinical)"
   * ^code[+] = HIVConcepts#HIV.D.DE939
-  * tbDiagnosisResult from HIV.D.DE939
+* tbDiagnosisResult from HIV.D.DE939
 * methodOfTbDiagnosis 0..1 Coding "Method of TB diagnosis" "Method used to set the TB diagnosis"
   * ^code[+] = HIVConcepts#HIV.D.DE942
-  * methodOfTbDiagnosis from HIV.D.DE942
+* methodOfTbDiagnosis from HIV.D.DE942
 * presumptiveTb 0..1 boolean "Presumptive TB" "Client has signs or symptoms of tuberculosis (TB) without laboratory confirmation"
   * ^code[+] = HIVConcepts#HIV.D.DE945
 * presumptiveTbRegistrationDate 0..1 date "Presumptive TB registration date" "Date client is registered as having signs or symptoms of tuberculosis (TB) without laboratory confirmation"
   * ^code[+] = HIVConcepts#HIV.D.DE946
 * tbTreatmentHistory 0..1 Coding "TB treatment history" "History of previous TB treatment"
   * ^code[+] = HIVConcepts#HIV.D.DE947
-  * tbTreatmentHistory from HIV.D.DE947
+* tbTreatmentHistory from HIV.D.DE947
 * dateOfTbDiagnosis 0..1 date "Date of TB diagnosis" "The date when the diagnosis was established"
   * ^code[+] = HIVConcepts#HIV.D.DE952
-* currentlyOnTbPreventiveTreatment 1..1 boolean "Currently on TB preventive treatment (TPT)" "Client is currently taking TPT"
+* currentlyOnTbPreventiveTreatmentTpt 1..1 boolean "Currently on TB preventive treatment (TPT)" "Client is currently taking TPT"
   * ^code[+] = HIVConcepts#HIV.D.DE953
-* tbPreventiveTreatmentpstartDate 0..1 date "TB preventive treatment (TPT) start date" "The date on which the client began taking TPT"
+* tbPreventiveTreatmentTptStartDate 0..1 date "TB preventive treatment (TPT) start date" "The date on which the client began taking TPT"
   * ^code[+] = HIVConcepts#HIV.D.DE954
-* tbPreventiveTreatmentpcompletionDate 0..1 date "TB preventive treatment (TPT) completion date" "The date on which the client completed TPT"
+* tbPreventiveTreatmentTptCompletionDate 0..1 date "TB preventive treatment (TPT) completion date" "The date on which the client completed TPT"
   * ^code[+] = HIVConcepts#HIV.D.DE955
 * tbScreeningAlgorithm 0..* Coding "TB screening algorithm" "Screening algorithm selected for screening activities"
   * ^code[+] = HIVConcepts#HIV.D.DE956
-  * tbScreeningAlgorithm from HIV.D.DE956
-* otherTbScreeningAlgorithm 0..1 string "Other TB screening algorithm (specify)" "Client screened for tuberculosis (TB) with a different screening method not listed (specify)"
+* tbScreeningAlgorithm from HIV.D.DE956
+* otherTbScreeningAlgorithmSpecify 0..1 string "Other TB screening algorithm (specify)" "Client screened for tuberculosis (TB) with a different screening method not listed (specify)"
   * ^code[+] = HIVConcepts#HIV.D.DE971
 * tbScreeningConducted 0..1 boolean "TB screening conducted" "A screening for tuberculosis (TB) was performed"
   * ^code[+] = HIVConcepts#HIV.D.DE972
 * symptomsOfTb 0..1 Coding "Symptoms of TB" "Symptoms that may indicate TB disease in clients living with HIV, based on a clinical algorithm"
   * ^code[+] = HIVConcepts#HIV.D.DE973
-  * symptomsOfTb from HIV.D.DE973
+* symptomsOfTb from HIV.D.DE973
 * historyOfContactWithAPersonWithTb 0..1 boolean "History of contact with a person with TB" "Client had a history of a contact with a person with TB"
   * ^code[+] = HIVConcepts#HIV.D.DE985
 * tbScreeningResult 0..1 Coding "TB screening result" "Record the result of the tuberculosis (TB) screening"
   * ^code[+] = HIVConcepts#HIV.D.DE986
-  * tbScreeningResult from HIV.D.DE986
+* tbScreeningResult from HIV.D.DE986
 * tbScreeningDate 0..1 date "TB screening date" "Date the TB screening was conducted"
   * ^code[+] = HIVConcepts#HIV.D.DE990
 * tbScreeningResultDate 0..1 date "TB screening result date" "The date when the result of TB screening is available"
   * ^code[+] = HIVConcepts#HIV.D.DE991
 * tbDiagnosticTestCategory 0..1 Coding "TB diagnostic test category" "The type of diagnostic test performed to detect tuberculosis (TB) disease"
   * ^code[+] = HIVConcepts#HIV.D.DE992
-  * tbDiagnosticTestCategory from HIV.D.DE992
+* tbDiagnosticTestCategory from HIV.D.DE992
 * tbDiagnosticTestDate 0..1 date "TB diagnostic test date" "The date when TB diagnostic test was performed"
   * ^code[+] = HIVConcepts#HIV.D.DE997
 * testSampleCollectionDate 0..1 date "Test sample collection date" "The date when the test sample was collected from the client"
@@ -78,19 +78,19 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE1001
 * tbTreatmentOutcome 0..1 Coding "TB treatment outcome" "Indicates patient's TB treatment outcome"
   * ^code[+] = HIVConcepts#HIV.D.DE1002
-  * tbTreatmentOutcome from HIV.D.DE1002
+* tbTreatmentOutcome from HIV.D.DE1002
 * tbTreatmentCompletionDate 0..1 date "TB treatment completion date" "Date client completes TB treatment"
   * ^code[+] = HIVConcepts#HIV.D.DE1009
 * tbTreatmentRegimenComposition 0..* Coding "TB treatment regimen composition" "TB drugs currently being taken by the client"
   * ^code[+] = HIVConcepts#HIV.D.DE1010
-  * tbTreatmentRegimenComposition from HIV.D.DE1010
+* tbTreatmentRegimenComposition from HIV.D.DE1010
 * eligibleForTbPreventiveTreatment 0..1 boolean "Eligible for TB preventive treatment" "Client is eligible for tuberculosis preventive treatment (TPT)"
   * ^code[+] = HIVConcepts#HIV.D.DE1017
-* dateWhenEligibilityForTbPreventiveTreatmentpwasDetermined 0..1 date "Date when eligibility for TB preventive treatment (TPT) was determined" "Date when a determination of the client's eligibility for TPT was made"
+* dateWhenEligibilityForTbPreventiveTreatmentTptWasDetermined 0..1 date "Date when eligibility for TB preventive treatment (TPT) was determined" "Date when a determination of the client's eligibility for TPT was made"
   * ^code[+] = HIVConcepts#HIV.D.DE1018
 * tbStatusAtArtStart 0..1 Coding "TB status at ART start" "Client's tuberculosis (TB) status when antiretroviral therapy (ART) is started"
   * ^code[+] = HIVConcepts#HIV.D.DE1019
-  * tbStatusAtArtStart from HIV.D.DE1019
+* tbStatusAtArtStart from HIV.D.DE1019
 * tbPreventionServicesAccepted 0..1 boolean "TB prevention services accepted" "Indicates if the client accepts to be evaluated for TB infection and to take the treatment in case he/she is eligible"
   * ^code[+] = HIVConcepts#HIV.D.DE1023
 * tbMeningitis 0..1 boolean "TB meningitis" "Type of extrapulmonary TB identified for the client is TB meningitis"
@@ -103,7 +103,7 @@ Description: "This tab describes the data that may be collected during care and 
   * ^code[+] = HIVConcepts#HIV.D.DE1027
 * tptRegimenType 0..1 Coding "TPT regimen type" "Type of TPT regimen the client is currently on"
   * ^code[+] = HIVConcepts#HIV.D.DE1028
-  * tptRegimenType from HIV.D.DE1028
-* tbPreventiveTreatmentpstatus 0..1 Coding "TB preventive treatment (TPT) status" "Indicates the current status of TB preventive treatment (TPT)"
+* tptRegimenType from HIV.D.DE1028
+* tbPreventiveTreatmentTptStatus 0..1 Coding "TB preventive treatment (TPT) status" "Indicates the current status of TB preventive treatment (TPT)"
   * ^code[+] = HIVConcepts#HIV.D.DE1034
-  * tbPreventiveTreatmentpstatus from HIV.D.DE1034
+* tbPreventiveTreatmentTptStatus from HIV.D.DE1034

--- a/input/fsh/models/HIVEFPMTCT.fsh
+++ b/input/fsh/models/HIVEFPMTCT.fsh
@@ -1,151 +1,151 @@
-Invariant:    HIV-E-F-1
+Invariant:    HIV-E-1
 Description:  "'Date of birth' OR 'Date of birth unknown' OR 'Estimated age' should be entered."
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-2
+Invariant:    HIV-E-2
 Description:  "'Date of death infant'' ≤ Date in which data is entered"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-3
+Invariant:    HIV-E-3
 Description:  "'Delivery date' ≤ Date in which data is entered"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-4
+Invariant:    HIV-E-4
 Description:  "'Infant HIV status' ≠ 'HIV-positive' and 'Infant HIV status' ≠ 'HIV-negative'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-5
+Invariant:    HIV-E-5
 Description:  "'Infant HIV status'='HIV-negative'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-6
+Invariant:    HIV-E-6
 Description:  "'Infant HIV status'='HIV-positive'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-7
+Invariant:    HIV-E-7
 Description:  "'Infant's co-trimoxazole prophylaxis start date' - 'Infant date of birth' ≤ 24 months"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-8
+Invariant:    HIV-E-8
 Description:  "'Maternal HIV status'='HIV-positive'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-9
+Invariant:    HIV-E-9
 Description:  "0 kg > 'Birth weight' ≥ 10kg"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-10
+Invariant:    HIV-E-10
 Description:  "0 kg > 'Infant weight' ≥ 20 kg"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-11
+Invariant:    HIV-E-11
 Description:  "0 ≤ 'Number of caesarian sections' ≤ ''Parity'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-12
+Invariant:    HIV-E-12
 Description:  "0 ≤ 'Number of live births' ≤ ('Number of previous pregnancies' - 'Number of miscarriages and/or abortions')"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-13
+Invariant:    HIV-E-13
 Description:  "0 ≤ 'Number of miscarriages and/or abortions' ≤ 'Number of previous pregnancies'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-14
+Invariant:    HIV-E-14
 Description:  "0 ≤ 'Number of stillbirths' ≤ ('Number of previous pregnancies' - 'Number of miscarriages and/or abortions' - 'Number of live births')"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-15
+Invariant:    HIV-E-15
 Description:  "1 ≤ 'Number of pregnancies (gravida)' ≤ 15"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-16
+Invariant:    HIV-E-16
 Description:  "20 cm ≥ 'Infant height' ≥ 100 cm"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-17
+Invariant:    HIV-E-17
 Description:  "4 weeks ≤ 'Gestational age' ≤ 40 weeks"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-18
+Invariant:    HIV-E-18
 Description:  "Calculated from 'Birth weight'"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-19
+Invariant:    HIV-E-19
 Description:  "Date of death' ≤ Date in which data is entered"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-20
+Invariant:    HIV-E-20
 Description:  "Date of miscarriage/abortion' ≤ Date in which data is entered"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-21
+Invariant:    HIV-E-21
 Description:  "Date ≤ Current Date"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-22
+Invariant:    HIV-E-22
 Description:  "DateTime ≤ Current DateTime"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-23
+Invariant:    HIV-E-23
 Description:  "If 'Date of birth unknown' = True, 'Estimated age' is required"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-24
+Invariant:    HIV-E-24
 Description:  "If 'Key population member type' is NOT NULL"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-25
+Invariant:    HIV-E-25
 Description:  "Include if Pregnant = True"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-26
+Invariant:    HIV-E-26
 Description:  "Minimum and maximum number of characters based on local policy"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-27
+Invariant:    HIV-E-27
 Description:  "Only letters and special characters (period, dash) allowed"
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Invariant:    HIV-E-F-28
+Invariant:    HIV-E-28
 Description:  "Only letters and special characters (period, dash) allowed."
 Expression:   "<NOT-IMPLEMENTED>"
 Severity:     #error
 
-Logical: HIVEFPMTCT
+Logical: HIVEPMTCT
 Title: "HIV.E-F PMTCT"
 Description: "This tab describes the data that are collected relevant to HIV care and treatment of pregnant and postpartum women and their newborns during the delivery and postpartum care and the infant diagnosis and final HIV status workflows (HIV.E and HIV.F)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablestructuredefinition"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablestructuredefinition"
 * ^extension[http://hl7.org/fhir/tools/StructureDefinition/logical-target].valueBoolean = true
 * ^experimental = true
-* ^name = "HIVEFPMTCT"
+* ^name = "HIVEPMTCT"
 * ^status = #active
 
 * pregnantWomanFirstName 0..1 string "Pregnant woman's first name" "Pregnant woman's first or given name"
@@ -160,10 +160,10 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE5
 * sourceOfGestationalAge 1..1 Coding "Source of gestational age" "Gestational age can be calculated multiple ways. This data element describes where the gestational age above has been calculated from."
   * ^code[+] = HIVConcepts#HIV.E.DE6
-  * sourceOfGestationalAge from HIV.E.DE6
-* expectedDateOfDelivery 1..1 date "Expected date of delivery (EDD)" "Expected date of delivery based on gestational age"
+* sourceOfGestationalAge from HIV.E.DE6
+* expectedDateOfDeliveryEdd 1..1 date "Expected date of delivery (EDD)" "Expected date of delivery based on gestational age"
   * ^code[+] = HIVConcepts#HIV.E.DE10
-* numberOfPregnancies 1..1 integer "Number of pregnancies (gravida)" "Total number of times the woman has been pregnant (including this pregnancy). Also referred to as gravida."
+* numberOfPregnanciesGravida 1..1 integer "Number of pregnancies (gravida)" "Total number of times the woman has been pregnant (including this pregnancy). Also referred to as gravida."
   * ^code[+] = HIVConcepts#HIV.E.DE11
 * numberOfPreviousPregnancies 1..1 integer "Number of previous pregnancies" "This calculates the total number of all previous pregnancies (i.e. not including this current pregnancy). This is done for easier obstetric history calculations."
   * ^code[+] = HIVConcepts#HIV.E.DE12
@@ -177,8 +177,8 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE16
 * pastPregnancyComplications 0..* Coding "Past pregnancy complications" "Whether the woman has had any complications or problems in any previous pregnancy"
   * ^code[+] = HIVConcepts#HIV.E.DE17
-  * pastPregnancyComplications from HIV.E.DE17
-* otherPastPregnancyProblems 0..1 string "Other past pregnancy problems (specify)" "Woman experienced other past pregnancy problems not described above (specify)"
+* pastPregnancyComplications from HIV.E.DE17
+* otherPastPregnancyProblemsSpecify 0..1 string "Other past pregnancy problems (specify)" "Woman experienced other past pregnancy problems not described above (specify)"
   * ^code[+] = HIVConcepts#HIV.E.DE35
 * parity 1..1 integer "Parity" "Total number of live and stillbirths (calculated)"
   * ^code[+] = HIVConcepts#HIV.E.DE36
@@ -192,18 +192,18 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE40
 * timingOfArtInitiation 0..1 Coding "Timing of ART initiation" "When the pregnant woman or mother initiated ART, for women living with HIV."
   * ^code[+] = HIVConcepts#HIV.E.DE41
-  * timingOfArtInitiation from HIV.E.DE41
+* timingOfArtInitiation from HIV.E.DE41
 * maternalUseOfRecommendedArtRegimen 0..1 boolean "Maternal use of recommended ART regimen" "Whether the mother is taking a recommended ART regimen"
   * ^code[+] = HIVConcepts#HIV.E.DE45
 * deliveryDate 1..1 date "Delivery date" "Date on which the woman delivered"
   * ^code[+] = HIVConcepts#HIV.E.DE46
 * pregnancyOutcome 0..1 Coding "Pregnancy outcome" "Outcome of current pregnancy"
   * ^code[+] = HIVConcepts#HIV.E.DE47
-  * pregnancyOutcome from HIV.E.DE47
+* pregnancyOutcome from HIV.E.DE47
 * deliveryMode 0..1 Coding "Delivery mode" "Mode of delivery for current pregnancy"
   * ^code[+] = HIVConcepts#HIV.E.DE52
-  * deliveryMode from HIV.E.DE52
-* indicationsForCaesarianSection 0..1 string "Indications for caesarian section (C/S)" "Indications for caesarian section"
+* deliveryMode from HIV.E.DE52
+* indicationsForCaesarianSectionCS 0..1 string "Indications for caesarian section (C/S)" "Indications for caesarian section"
   * ^code[+] = HIVConcepts#HIV.E.DE56
 * obstetricComplications 0..1 string "Obstetric complications" "Serious or life-threatening obstetric complications during pregnancy, delivery or postpartum experienced by mother or her newborn"
   * ^code[+] = HIVConcepts#HIV.E.DE57
@@ -213,17 +213,17 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE59
 * gestationalAgeAtBirth 0..1 integer "Gestational age at birth" "Best estimate of gestational age in completed weeks when infant was born (an indication of prematurity, preterm and extreme preterm)"
   * ^code[+] = HIVConcepts#HIV.E.DE60
-* smallForGestationalAge 0..1 boolean "Small for gestational age (SGA)" "Whether the infant was small for gestational age (SGA) at birth (<10th percentile)"
+* smallForGestationalAgeSga 0..1 boolean "Small for gestational age (SGA)" "Whether the infant was small for gestational age (SGA) at birth (<10th percentile)"
   * ^code[+] = HIVConcepts#HIV.E.DE61
 * pretermBirthStatus 0..1 Coding "Preterm birth status" "The woman gave birth when the gestational age is less than 37 weeks"
   * ^code[+] = HIVConcepts#HIV.E.DE62
-  * pretermBirthStatus from HIV.E.DE62
+* pretermBirthStatus from HIV.E.DE62
 * maternalArtStartDate 0..1 date "Maternal ART start date" "The date on which the infant was started or restarted on ART"
   * ^code[+] = HIVConcepts#HIV.E.DE66
 * placeOfDelivery 1..1 Coding "Place of delivery" "The type of place where the woman delivered"
   * ^code[+] = HIVConcepts#HIV.E.DE67
-  * placeOfDelivery from HIV.E.DE67
-* other 0..1 string "Other (specify)" "The woman delivered at another location that is not at home or at a health facility (specify)"
+* placeOfDelivery from HIV.E.DE67
+* otherPlaceOfDelivery 0..1 string "Other (specify)" "The woman delivered at another location that is not at home or at a health facility (specify)"
   * ^code[+] = HIVConcepts#HIV.E.DE71
 * deliveryFacility 0..1 string "Delivery facility" "Facility where the infant or child was born"
   * ^code[+] = HIVConcepts#HIV.E.DE72
@@ -233,7 +233,7 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE74
 * causeOfDeathOfMother 0..1 Coding "Cause of death of mother" "The woman's cause of death"
   * ^code[+] = HIVConcepts#HIV.E.DE75
-  * causeOfDeathOfMother from HIV.E.DE75
+* causeOfDeathOfMother from HIV.E.DE75
 * infantFirstName 1..1 string "Infant's first name" "Infant's first or given name"
   * ^code[+] = HIVConcepts#HIV.E.DE76
 * infantSurname 1..1 string "Infant's surname" "Infant's family name or last name"
@@ -266,7 +266,7 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE90
 * genderOfInfant 1..1 Coding "Gender of infant" "Gender of the infant"
   * ^code[+] = HIVConcepts#HIV.E.DE91
-  * genderOfInfant from HIV.E.DE91
+* genderOfInfant from HIV.E.DE91
 * infantHeight 0..1 integer "Infant height" "The infant's height in centimetres"
   * ^code[+] = HIVConcepts#HIV.E.DE95
 * infantWeight 0..1 integer "Infant weight" "The infant's current weight in kilograms"
@@ -287,17 +287,17 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE103
 * maternalHivTestResult 0..1 Coding "Maternal HIV test result" "Test result for mother after applying the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE104
-  * maternalHivTestResult from HIV.E.DE104
+* maternalHivTestResult from HIV.E.DE104
 * infantOrChildExposureToHiv 1..1 Coding "Infant or child exposure to HIV" "Whether the infant or child was determined to have had HIV exposure through mother"
   * ^code[+] = HIVConcepts#HIV.E.DE108
-  * infantOrChildExposureToHiv from HIV.E.DE108
+* infantOrChildExposureToHiv from HIV.E.DE108
 * hivExposedInfantOrChild 0..1 boolean "HIV-exposed infant or child" "Whether the infant or child was determined to have had HIV exposure"
   * ^code[+] = HIVConcepts#HIV.E.DE112
 * keyPopulationMember 0..1 boolean "Key population member" "Mother is a member of a key population which has an increased risk of HIV"
   * ^code[+] = HIVConcepts#HIV.E.DE113
 * keyPopulationMemberType 0..* Coding "Key population member type" "The type of key population that the infant's mother is included in"
   * ^code[+] = HIVConcepts#HIV.E.DE114
-  * keyPopulationMemberType from HIV.E.DE114
+* keyPopulationMemberType from HIV.E.DE114
 * postpartumFamilyPlanningCounsellingConducted 0..1 boolean "Postpartum family planning counselling conducted" "Provide family planning and contraception counselling"
   * ^code[+] = HIVConcepts#HIV.E.DE119
 * ageOfInfantOnHivTestDate 0..1 integer "Age of infant on HIV test date" "Infant's age when an HIV test is performed in months and years (calculated from date of birth)"
@@ -310,46 +310,46 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE123
 * malariaPreventionCounsellingConducted 0..1 boolean "Malaria prevention counselling conducted" "Counselling provided on how to prevent malaria"
   * ^code[+] = HIVConcepts#HIV.E.DE124
-* insecticideTreatedBednettprovidedOrReferred 0..1 boolean "Insecticide treated bednet (ITN) provided or referred" "An insecticide treated bednet (ITN) was provided or the client was referred"
+* insecticideTreatedBednetItnProvidedOrReferred 0..1 boolean "Insecticide treated bednet (ITN) provided or referred" "An insecticide treated bednet (ITN) was provided or the client was referred"
   * ^code[+] = HIVConcepts#HIV.E.DE125
 * maternalSyphilisTreatment 1..1 boolean "Maternal syphilis treatment" "Whether or not mother was treated for syphilis"
   * ^code[+] = HIVConcepts#HIV.E.DE126
 * infantFeedingPractice 0..1 Coding "Infant feeding practice" "Infant feeding practice"
   * ^code[+] = HIVConcepts#HIV.E.DE127
-  * infantFeedingPractice from HIV.E.DE127
+* infantFeedingPractice from HIV.E.DE127
 * infantFeedingPracticeRecordedDate 0..1 date "Infant feeding practice recorded date" "Date on which infant feeding practice was recorded"
   * ^code[+] = HIVConcepts#HIV.E.DE131
 * stoppedBreastfeeding 0..1 boolean "Stopped breastfeeding" "The mother has fully stopped breastfeeding the infant or child"
   * ^code[+] = HIVConcepts#HIV.E.DE132
 * dateStoppedBreastfeeding 0..1 date "Date stopped breastfeeding" "The date on which the mother stopped breastfeeding the infant"
   * ^code[+] = HIVConcepts#HIV.E.DE133
-* takingIronAndFolicAcidftablets 0..1 boolean "Taking iron and folic acid (IFA) tablets" "Is client taking her iron and folic acid (IFA) tablets? Select whether the woman is continuing to take IFA supplements"
+* takingIronAndFolicAcidIfaTablets 0..1 boolean "Taking iron and folic acid (IFA) tablets" "Is client taking her iron and folic acid (IFA) tablets? Select whether the woman is continuing to take IFA supplements"
   * ^code[+] = HIVConcepts#HIV.E.DE134
 * amountOfIronPrescribed 0..1 integer "Amount of iron prescribed" "Amount of iron supplements prescribed in milligrams for intake"
   * ^code[+] = HIVConcepts#HIV.E.DE135
 * typeOfIronSupplementDosageProvided 0..1 Coding "Type of iron supplement dosage provided" "Whether the amount of iron prescribed is for daily or weekly intake"
   * ^code[+] = HIVConcepts#HIV.E.DE136
-  * typeOfIronSupplementDosageProvided from HIV.E.DE136
+* typeOfIronSupplementDosageProvided from HIV.E.DE136
 * amountOfDailyDoseOfFolicAcidPrescribed 0..1 integer "Amount of daily dose of folic acid prescribed" "Amount of folic acid supplements prescribed in milligrams for daily intake"
   * ^code[+] = HIVConcepts#HIV.E.DE139
-* dateInfantArvProphylaxisDispensed 0..1 date "Date infant ARV prophylaxis dispensed (or started)" "Date HIV-exposed infant received ARV prophylaxis (for the first time)"
+* dateInfantArvProphylaxisDispensedOrStarted 0..1 date "Date infant ARV prophylaxis dispensed (or started)" "Date HIV-exposed infant received ARV prophylaxis (for the first time)"
   * ^code[+] = HIVConcepts#HIV.E.DE140
 * maternalHivStatus 0..1 Coding "Maternal HIV status" "The HIV status of the infant's mother"
   * ^code[+] = HIVConcepts#HIV.E.DE141
-  * maternalHivStatus from HIV.E.DE141
+* maternalHivStatus from HIV.E.DE141
 * maternalHivStatusAtFirstAncVisit 0..1 Coding "Maternal HIV status at first ANC visit" "The HIV status of the infant's mother at first ANC visit"
   * ^code[+] = HIVConcepts#HIV.E.DE145
-  * maternalHivStatusAtFirstAncVisit from HIV.E.DE145
+* maternalHivStatusAtFirstAncVisit from HIV.E.DE145
 * maternalSyphilisTestResult 0..1 Coding "Maternal syphilis test result" "Result from maternal syphilis test"
   * ^code[+] = HIVConcepts#HIV.E.DE149
-  * maternalSyphilisTestResult from HIV.E.DE149
+* maternalSyphilisTestResult from HIV.E.DE149
 * hypertension 0..1 boolean "Hypertension" "Whether the client has developed hypertension associated with pregnancy"
   * ^code[+] = HIVConcepts#HIV.E.DE153
 * preEclampsia 0..1 boolean "Pre-eclampsia" "Whether the client has pre-eclampsia"
   * ^code[+] = HIVConcepts#HIV.E.DE154
 * signsOfSubstantialRiskOfHivInfection 1..* Coding "Signs of substantial risk of HIV infection" "Signs the client is at a substantial risk of HIV infection"
   * ^code[+] = HIVConcepts#HIV.E.DE155
-  * signsOfSubstantialRiskOfHivInfection from HIV.E.DE155
+* signsOfSubstantialRiskOfHivInfection from HIV.E.DE155
 * serodiscordantPartner 0..1 boolean "Serodiscordant partner" "Mother's HIV status is different from a current partner's HIV status"
   * ^code[+] = HIVConcepts#HIV.E.DE160
 * dateWomanReceivedCounsellingForCpt 0..1 date "Date woman received counselling for CPT" "Date woman received counselling for co-trimoxazole preventive therapy (CPT)"
@@ -368,10 +368,10 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE167
 * hivTestType 0..1 Coding "HIV test type" "Type of HIV test"
   * ^code[+] = HIVConcepts#HIV.E.DE168
-  * hivTestType from HIV.E.DE168
+* hivTestType from HIV.E.DE168
 * maternalAndChildHealthServiceVisit 0..1 Coding "Maternal and child health service visit" "Maternal and child health service visit attended by an HIV-exposed infant"
   * ^code[+] = HIVConcepts#HIV.E.DE173
-  * maternalAndChildHealthServiceVisit from HIV.E.DE173
+* maternalAndChildHealthServiceVisit from HIV.E.DE173
 * weeksPostpartum 0..1 integer "Weeks postpartum" "Number of weeks postpartum on this visit date"
   * ^code[+] = HIVConcepts#HIV.E.DE177
 * birthCohort 1..1 date "Birth cohort" "Month and year of infant's birth, which the infant is registered into. The cohort is a group of infants born in the same month, whose status is followed over time."
@@ -380,74 +380,74 @@ Description: "This tab describes the data that are collected relevant to HIV car
   * ^code[+] = HIVConcepts#HIV.E.DE179
 * eidSampleNumber 0..1 Coding "EID sample number" "Early infant diagnosis (EID) sample number"
   * ^code[+] = HIVConcepts#HIV.E.DE180
-  * eidSampleNumber from HIV.E.DE180
+* eidSampleNumber from HIV.E.DE180
 * eidTestNumber 0..1 Coding "EID test number" "Early infant diagnosis (EID) HIV test number using the same sample"
   * ^code[+] = HIVConcepts#HIV.E.DE183
-  * eidTestNumber from HIV.E.DE183
-* eidTestNumber_1TestResult 0..1 Coding "EID test number 1 test result" "Early infant diagnosis test number 1 test result"
+* eidTestNumber from HIV.E.DE183
+* eidTestNumber1TestResult 0..1 Coding "EID test number 1 test result" "Early infant diagnosis test number 1 test result"
   * ^code[+] = HIVConcepts#HIV.E.DE186
-  * eidTestNumber_1TestResult from HIV.E.DE186
-* eidTestNumber_2TestResult 0..1 Coding "EID test number 2 test result" "Early infant diagnosis test number 2 test result"
+* eidTestNumber1TestResult from HIV.E.DE186
+* eidTestNumber2TestResult 0..1 Coding "EID test number 2 test result" "Early infant diagnosis test number 2 test result"
   * ^code[+] = HIVConcepts#HIV.E.DE190
-  * eidTestNumber_2TestResult from HIV.E.DE190
+* eidTestNumber2TestResult from HIV.E.DE190
 * assayNumberInTestingStrategy 0..1 Coding "Assay number in testing strategy" "The number of the assay (test kit) in the HIV testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE194
-  * assayNumberInTestingStrategy from HIV.E.DE194
-* testResultOfHivAssay_1 0..1 Coding "Test result of HIV assay 1" "The result of the first HIV assay in the testing strategy"
+* assayNumberInTestingStrategy from HIV.E.DE194
+* testResultOfHivAssay1 0..1 Coding "Test result of HIV assay 1" "The result of the first HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE200
-  * testResultOfHivAssay_1 from HIV.E.DE200
-* testResultOfHivAssay_2 0..1 Coding "Test result of HIV assay 2" "The result of the second HIV assay in the testing strategy"
+* testResultOfHivAssay1 from HIV.E.DE200
+* testResultOfHivAssay2 0..1 Coding "Test result of HIV assay 2" "The result of the second HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE204
-  * testResultOfHivAssay_2 from HIV.E.DE204
-* testResultOfHivAssay_3 0..1 Coding "Test result of HIV assay 3" "The result of the third HIV assay in the testing strategy"
+* testResultOfHivAssay2 from HIV.E.DE204
+* testResultOfHivAssay3 0..1 Coding "Test result of HIV assay 3" "The result of the third HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE208
-  * testResultOfHivAssay_3 from HIV.E.DE208
-* testResultOfHivAssay_1Repeated 0..1 Coding "Test result of HIV assay 1 repeated" "The result of the repeated first HIV assay in the testing strategy"
+* testResultOfHivAssay3 from HIV.E.DE208
+* testResultOfHivAssay1Repeated 0..1 Coding "Test result of HIV assay 1 repeated" "The result of the repeated first HIV assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE212
-  * testResultOfHivAssay_1Repeated from HIV.E.DE212
-* testResultOfSyphilisAssay_1 0..1 Coding "Test result of syphilis assay 1" "The result of the first syphilis assay in the testing strategy"
+* testResultOfHivAssay1Repeated from HIV.E.DE212
+* testResultOfSyphilisAssay1 0..1 Coding "Test result of syphilis assay 1" "The result of the first syphilis assay in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE216
-  * testResultOfSyphilisAssay_1 from HIV.E.DE216
-* testResultOfSyphilisAssay_1Repeated 0..1 Coding "Test result of syphilis assay 1 repeated" "The result of the first syphilis assay repeated in the testing strategy"
+* testResultOfSyphilisAssay1 from HIV.E.DE216
+* testResultOfSyphilisAssay1Repeated 0..1 Coding "Test result of syphilis assay 1 repeated" "The result of the first syphilis assay repeated in the testing strategy"
   * ^code[+] = HIVConcepts#HIV.E.DE220
-  * testResultOfSyphilisAssay_1Repeated from HIV.E.DE220
+* testResultOfSyphilisAssay1Repeated from HIV.E.DE220
 * hivTestDate 0..1 date "HIV test date" "Date of the HIV test"
   * ^code[+] = HIVConcepts#HIV.E.DE224
 * infantHivStatus 1..1 Coding "Infant HIV status" "HIV status reported after applying the HIV testing algorithm. No single HIV test can provide an HIV-positive diagnosis."
   * ^code[+] = HIVConcepts#HIV.E.DE225
-  * infantHivStatus from HIV.E.DE225
+* infantHivStatus from HIV.E.DE225
 * infantArtStartDate 0..1 date "Infant ART start date" "The date on which the infant was started or restarted on antiretroviral therapy (ART)"
   * ^code[+] = HIVConcepts#HIV.E.DE229
 * finalDiagnosisOfHivExposedInfant 0..1 Coding "Final diagnosis of HIV-exposed infant" "HIV-exposed infant final status at 18 months or 3 months after cessation of breastfeeding (whichever is later)."
   * ^code[+] = HIVConcepts#HIV.E.DE230
-  * finalDiagnosisOfHivExposedInfant from HIV.E.DE230
+* finalDiagnosisOfHivExposedInfant from HIV.E.DE230
 * hivExposedInfantReasonForUnknownFinalStatus 0..1 Coding "HIV-exposed infant reason for unknown final status" "The outcome for the infant does not have a final outcome, which may because of death, stopped treatment or lost to follow-up."
   * ^code[+] = HIVConcepts#HIV.E.DE234
-  * hivExposedInfantReasonForUnknownFinalStatus from HIV.E.DE234
+* hivExposedInfantReasonForUnknownFinalStatus from HIV.E.DE234
 * dateOfDeathOfInfant 0..1 dateTime "Date of death of infant" "Date that the infant died"
   * ^code[+] = HIVConcepts#HIV.E.DE239
 * causeOfDeathOfInfant 0..1 Coding "Cause of death of infant" "The infant's cause of death"
   * ^code[+] = HIVConcepts#HIV.E.DE240
-  * causeOfDeathOfInfant from HIV.E.DE240
-* infantDiedWithin_24HoursOfChildbirth 0..1 boolean "Infant died within 24 hours of childbirth" "The infant died within 24 hours of childbirth"
+* causeOfDeathOfInfant from HIV.E.DE240
+* infantDiedWithin24HoursOfChildbirth 0..1 boolean "Infant died within 24 hours of childbirth" "The infant died within 24 hours of childbirth"
   * ^code[+] = HIVConcepts#HIV.E.DE241
-* actio)NeededDuringInfantFollowUpVisit 0..1 string "Action(s) needed during infant follow-up visit" "Any actions needed during infant follow-up visit"
+* actionsNeededDuringInfantFollowUpVisit 0..1 string "Action(s) needed during infant follow-up visit" "Any actions needed during infant follow-up visit"
   * ^code[+] = HIVConcepts#HIV.E.DE242
 * timingOfAdditionalInfantHivTest 0..1 integer "Timing of additional infant HIV test" "Age in months when additional infant HIV test is performed"
   * ^code[+] = HIVConcepts#HIV.E.DE243
 * dateOfSampleCollectionOfAdditionalInfantHivTest 0..1 date "Date of sample collection of additional infant HIV test" "Date of sample collection of additional infant HIV test"
   * ^code[+] = HIVConcepts#HIV.E.DE244
-* haemoglobinresult 0..1 integer "Haemoglobin (Hb) result" "Result of woman's haemoglobin test during ANC, labour or delivery. Full blood count testing is recommended, and if not available, use of  haemoglobinometer over haemoglobin colour scale. "
+* haemoglobinHbResult 0..1 integer "Haemoglobin (Hb) result" "Result of woman's haemoglobin test during ANC, labour or delivery. Full blood count testing is recommended, and if not available, use of  haemoglobinometer over haemoglobin colour scale. "
   * ^code[+] = HIVConcepts#HIV.E.DE245
 * bloodGroupAndRhFactor 0..1 Coding "Blood group and Rh factor" "Mother's blood type and blood Rh factor"
   * ^code[+] = HIVConcepts#HIV.E.DE246
-  * bloodGroupAndRhFactor from HIV.E.DE246
-* asymptomaticBacteriuriastestResult 0..1 Coding "Asymptomatic bacteriuria (ASB) test result" "Result of urine culture (or urine Gram-staining if not available over dipstick tests) for diagnosing asymptomatic bacteriuria"
+* bloodGroupAndRhFactor from HIV.E.DE246
+* asymptomaticBacteriuriaAsbTestResult 0..1 Coding "Asymptomatic bacteriuria (ASB) test result" "Result of urine culture (or urine Gram-staining if not available over dipstick tests) for diagnosing asymptomatic bacteriuria"
   * ^code[+] = HIVConcepts#HIV.E.DE255
-  * asymptomaticBacteriuriastestResult from HIV.E.DE255
+* asymptomaticBacteriuriaAsbTestResult from HIV.E.DE255
 * urineProteinTestResult 0..1 Coding "Urine protein test result" "Results of urine protein test of mother during ANC visit"
   * ^code[+] = HIVConcepts#HIV.E.DE259
-  * urineProteinTestResult from HIV.E.DE259
+* urineProteinTestResult from HIV.E.DE259
 * typeOfHypertensiveDisorder 0..* Coding "Type of hypertensive disorder" "Type of hypertensive disorder of the mother"
   * ^code[+] = HIVConcepts#HIV.E.DE264
-  * typeOfHypertensiveDisorder from HIV.E.DE264
+* typeOfHypertensiveDisorder from HIV.E.DE264

--- a/input/fsh/models/HIVGDiagnostics.fsh
+++ b/input/fsh/models/HIVGDiagnostics.fsh
@@ -44,20 +44,20 @@ Description: "This tab describes the data that are collected during the workflow
   * ^code[+] = HIVConcepts#HIV.G.DE12
 * hivViralLoadSpecimenType 0..1 Coding "HIV viral load specimen type" "The type of specimen to be used to test viral load"
   * ^code[+] = HIVConcepts#HIV.G.DE13
-  * hivViralLoadSpecimenType from HIV.G.DE13
+* hivViralLoadSpecimenType from HIV.G.DE13
 * hbsagTestDate 0..1 date "HBsAg test date" "Date client was tested for hepatitis B virus (HBV)"
   * ^code[+] = HIVConcepts#HIV.G.DE17
 * hbsagTestResult 0..1 Coding "HBsAg test result" "Hepatitis B virus test result (HBsAg)"
   * ^code[+] = HIVConcepts#HIV.G.DE18
-  * hbsagTestResult from HIV.G.DE18
+* hbsagTestResult from HIV.G.DE18
 * reasonHepatitisBTestNotConducted 0..* Coding "Reason Hepatitis B test not conducted" "Reason why a hepatitis B test was not done"
   * ^code[+] = HIVConcepts#HIV.G.DE22
-  * reasonHepatitisBTestNotConducted from HIV.G.DE22
-* other 0..1 string "Other (specify)" "Other reason test not performed (specify)"
+* reasonHepatitisBTestNotConducted from HIV.G.DE22
+* otherReasonHepatitisBTestNotConducted 0..1 string "Other (specify)" "Other reason test not performed (specify)"
   * ^code[+] = HIVConcepts#HIV.G.DE28
 * hepatitisBDiagnosis 0..1 Coding "Hepatitis B diagnosis" "Client's hepatitis B diagnosis"
   * ^code[+] = HIVConcepts#HIV.G.DE29
-  * hepatitisBDiagnosis from HIV.G.DE29
+* hepatitisBDiagnosis from HIV.G.DE29
 * hepatitisCScreeningDate 0..1 dateTime "Hepatitis C screening date" "Date when client was screened for HCV"
   * ^code[+] = HIVConcepts#HIV.G.DE32
 * hepatitisCTestOrdered 1..1 boolean "Hepatitis C test ordered" "Hepatitis C test has been ordered"
@@ -66,47 +66,47 @@ Description: "This tab describes the data that are collected during the workflow
   * ^code[+] = HIVConcepts#HIV.G.DE34
 * reasonHepatitisCTestNotDone 0..* Coding "Reason Hepatitis C test not done" "Reason why a hepatitis C test was not done"
   * ^code[+] = HIVConcepts#HIV.G.DE35
-  * reasonHepatitisCTestNotDone from HIV.G.DE35
-* other 0..1 string "Other (specify)" "Other reason test not performed (specify)"
+* reasonHepatitisCTestNotDone from HIV.G.DE35
+* otherReasonHepatitisCTestNotDone 0..1 string "Other (specify)" "Other reason test not performed (specify)"
   * ^code[+] = HIVConcepts#HIV.G.DE41
 * hcvTestDate 0..1 date "HCV test date" "Date client was tested for hepatitis C virus (HCV antibody, HCV RNA or HCV core antigen)"
   * ^code[+] = HIVConcepts#HIV.G.DE42
 * hcvTestResult 0..1 Coding "HCV test result" "Hepatitis C virus test result (HCV antibody, HCV RNA or HCV core antigen)"
   * ^code[+] = HIVConcepts#HIV.G.DE43
-  * hcvTestResult from HIV.G.DE43
+* hcvTestResult from HIV.G.DE43
 * hcvViralLoadTestDate 0..1 integer "HCV viral load test date" "Hepatitis C viral load test date"
   * ^code[+] = HIVConcepts#HIV.G.DE47
 * hcvViralLoadTestResult 0..1 Coding "HCV viral load test result" "Hepatitis C viral load test result (qualitative)"
   * ^code[+] = HIVConcepts#HIV.G.DE48
-  * hcvViralLoadTestResult from HIV.G.DE48
+* hcvViralLoadTestResult from HIV.G.DE48
 * hepatitisCDiagnosis 0..1 Coding "Hepatitis C diagnosis" "Client's hepatitis C diagnosis"
   * ^code[+] = HIVConcepts#HIV.G.DE51
-  * hepatitisCDiagnosis from HIV.G.DE51
+* hepatitisCDiagnosis from HIV.G.DE51
 * syphilisTestRequired 1..1 boolean "Syphilis test required" "Syphilis test is required"
   * ^code[+] = HIVConcepts#HIV.G.DE54
 * syphilisTestType 0..* Coding "Syphilis test type" "Type of diagnostic test used for syphilis (treponema pallidum)"
   * ^code[+] = HIVConcepts#HIV.G.DE55
-  * syphilisTestType from HIV.G.DE55
-* otherSyphilisTestType 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
+* syphilisTestType from HIV.G.DE55
+* otherSyphilisTestTypeSpecify 0..1 string "Other syphilis test type (specify)" "Other test used (specify)"
   * ^code[+] = HIVConcepts#HIV.G.DE61
 * reasonSyphilisTestNotDone 0..* Coding "Reason syphilis test not done" "Reason why a syphilis test was not done"
   * ^code[+] = HIVConcepts#HIV.G.DE62
-  * reasonSyphilisTestNotDone from HIV.G.DE62
-* other 0..1 string "Other (specify)" "Other reason test not performed (specify)"
+* reasonSyphilisTestNotDone from HIV.G.DE62
+* otherReasonSyphilisTestNotDone 0..1 string "Other (specify)" "Other reason test not performed (specify)"
   * ^code[+] = HIVConcepts#HIV.G.DE68
 * syphilisTestDate 0..1 date "Syphilis test date" "Date of syphilis test"
   * ^code[+] = HIVConcepts#HIV.G.DE69
 * syphilisTestResult 0..1 Coding "Syphilis test result" "Result from syphilis test"
   * ^code[+] = HIVConcepts#HIV.G.DE70
-  * syphilisTestResult from HIV.G.DE70
+* syphilisTestResult from HIV.G.DE70
 * syphilisDiagnosis 0..1 Coding "Syphilis diagnosis" "Client's syphilis diagnosis"
   * ^code[+] = HIVConcepts#HIV.G.DE74
-  * syphilisDiagnosis from HIV.G.DE74
+* syphilisDiagnosis from HIV.G.DE74
 * otherTestsConducted 0..1 boolean "Other tests conducted" "If the health worker performed other tests on the woman that are not explicitly listed in the application, select 'yes' here and fill in the details below."
   * ^code[+] = HIVConcepts#HIV.G.DE77
-* otherTes)Name 0..1 string "Other test(s) name" "Input the name of other test(s) that were done."
+* otherTestsName 0..1 string "Other test(s) name" "Input the name of other test(s) that were done."
   * ^code[+] = HIVConcepts#HIV.G.DE78
-* otherTes)Date 0..1 date "Other test(s) date" "Input the date of other test(s) that were done."
+* otherTestsDate 0..1 date "Other test(s) date" "Input the date of other test(s) that were done."
   * ^code[+] = HIVConcepts#HIV.G.DE79
-* otherTes)Result 0..1 string "Other test(s) result(s)" "Input the result from the test(s)."
+* otherTestsResults 0..1 string "Other test(s) result(s)" "Input the result from the test(s)."
   * ^code[+] = HIVConcepts#HIV.G.DE80

--- a/input/fsh/models/HIVHFollowup.fsh
+++ b/input/fsh/models/HIVHFollowup.fsh
@@ -20,8 +20,8 @@ Description: "This tab describes the data that are collected during the follow-u
 
 * reasonForFollowUp 1..* Coding "Reason for follow-up" "The reason why the client is being followed up"
   * ^code[+] = HIVConcepts#HIV.H.DE1
-  * reasonForFollowUp from HIV.H.DE1
-* otherFollowUpReason 0..1 string "Other follow-up reason (specify)" "Client was followed up for another reason (specify)"
+* reasonForFollowUp from HIV.H.DE1
+* otherFollowUpReasonSpecify 0..1 string "Other follow-up reason (specify)" "Client was followed up for another reason (specify)"
   * ^code[+] = HIVConcepts#HIV.H.DE9
 * clientContactAttempted 0..1 boolean "Client contact attempted" "An attempt to locate the client was made"
   * ^code[+] = HIVConcepts#HIV.H.DE10
@@ -31,15 +31,15 @@ Description: "This tab describes the data that are collected during the follow-u
   * ^code[+] = HIVConcepts#HIV.H.DE12
 * contactMethod 1..1 Coding "Contact method" "Method used to try to reach out to the client"
   * ^code[+] = HIVConcepts#HIV.H.DE13
-  * contactMethod from HIV.H.DE13
+* contactMethod from HIV.H.DE13
 * sourceOfInformation 1..1 Coding "Source of information" "Source of information about the client"
   * ^code[+] = HIVConcepts#HIV.H.DE17
-  * sourceOfInformation from HIV.H.DE17
-* otherSourceOfInformation 0..1 string "Other source of information (specify)" "Information about the client's status was provided by someone else (specify)"
+* sourceOfInformation from HIV.H.DE17
+* otherSourceOfInformationSpecify 0..1 string "Other source of information (specify)" "Information about the client's status was provided by someone else (specify)"
   * ^code[+] = HIVConcepts#HIV.H.DE22
 * outcomeFromOutreachAttempt 0..1 Coding "Outcome from outreach attempt" "Detailed outcome from the attempt to locate the client"
   * ^code[+] = HIVConcepts#HIV.H.DE23
-  * outcomeFromOutreachAttempt from HIV.H.DE23
+* outcomeFromOutreachAttempt from HIV.H.DE23
 * movedFromCatchmentArea 0..1 boolean "Moved from catchment area" "The client moved from the catchment area (may be reported from the community level)"
   * ^code[+] = HIVConcepts#HIV.H.DE30
 * dateClientMovedFromCatchmentArea 0..1 date "Date client moved from catchment area" "The date on which the client moved from the catchment area, if known"
@@ -50,7 +50,7 @@ Description: "This tab describes the data that are collected during the follow-u
   * ^code[+] = HIVConcepts#HIV.H.DE33
 * hivStatusOfPartnerOrContact 0..1 Coding "HIV status of partner or contact" "HIV status of the partner or contact given by the index case"
   * ^code[+] = HIVConcepts#HIV.H.DE34
-  * hivStatusOfPartnerOrContact from HIV.H.DE34
+* hivStatusOfPartnerOrContact from HIV.H.DE34
 * dateOfDeath 0..1 date "Date of death" "If deceased, the date that the client died"
   * ^code[+] = HIVConcepts#HIV.H.DE38
 * causeOfDeath 0..1 string "Cause of death" "Cause of death, if known"
@@ -59,7 +59,7 @@ Description: "This tab describes the data that are collected during the follow-u
   * ^code[+] = HIVConcepts#HIV.H.DE40
 * hivTreatmentOutcome 0..1 Coding "HIV treatment outcome" "The outcome for the client which is used for reporting retention/attrition."
   * ^code[+] = HIVConcepts#HIV.H.DE41
-  * hivTreatmentOutcome from HIV.H.DE41
+* hivTreatmentOutcome from HIV.H.DE41
 * datePatientLostToFollowUp 0..1 date "Date patient lost to follow-up" "Date patient was lost to follow-up (LTFU)"
   * ^code[+] = HIVConcepts#HIV.H.DE46
 * onArt 0..1 boolean "On ART" "Client is currently taking ART "
@@ -70,20 +70,20 @@ Description: "This tab describes the data that are collected during the follow-u
   * ^code[+] = HIVConcepts#HIV.H.DE49
 * transferToFacility 0..1 Coding "Transfer to facility" "Name of health facility client was transferred to"
   * ^code[+] = HIVConcepts#HIV.H.DE50
-  * transferToFacility from HIV.H.DE50
+* transferToFacility from HIV.H.DE50
 * dateOfTransferOut 0..1 date "Date of transfer out" "The date the client transferred out of the facility to be provided with care at another facility"
   * ^code[+] = HIVConcepts#HIV.H.DE51
 * adherenceAssessment 0..1 boolean "Adherence assessment" "Whether client is adherent or not to ART regimen per national guidelines (immunological or virological monitoring)"
   * ^code[+] = HIVConcepts#HIV.H.DE52
-* reaso)ForAdherenceProblem 0..* Coding "Reason(s) for adherence problem" "Reason why client is not adherent"
+* reasonsForAdherenceProblem 0..* Coding "Reason(s) for adherence problem" "Reason why client is not adherent"
   * ^code[+] = HIVConcepts#HIV.H.DE53
-  * reaso)ForAdherenceProblem from HIV.H.DE53
-* other 0..1 string "Other (specify)" "Client reported not being adherent because of other reason (specify)"
+* reasonsForAdherenceProblem from HIV.H.DE53
+* otherReasonsForAdherenceProblem 0..1 string "Other (specify)" "Client reported not being adherent because of other reason (specify)"
   * ^code[+] = HIVConcepts#HIV.H.DE72
 * dateArtStopped 0..1 date "Date ART stopped" "Date on which client stopped ART"
   * ^code[+] = HIVConcepts#HIV.H.DE73
 * reasonArtStopped 0..* Coding "Reason ART stopped" "Reason why client intentionally stopped ART"
   * ^code[+] = HIVConcepts#HIV.H.DE74
-  * reasonArtStopped from HIV.H.DE74
-* otherReasonForStoppingArt 0..1 string "Other reason for stopping ART (specify)" "Client stopped ART for other reason (specify)"
+* reasonArtStopped from HIV.H.DE74
+* otherReasonForStoppingArtSpecify 0..1 string "Other reason for stopping ART (specify)" "Client stopped ART for other reason (specify)"
   * ^code[+] = HIVConcepts#HIV.H.DE81

--- a/input/fsh/models/HIVIReferral.fsh
+++ b/input/fsh/models/HIVIReferral.fsh
@@ -17,10 +17,10 @@ Description: "This tab describes the data that are collected during the referral
   * ^code[+] = HIVConcepts#HIV.I.DE1
 * reasonForReferral 1..* Coding "Reason for referral" "Reason why the client is being referred. If diagnosed, this may include the reason for the diagnosis."
   * ^code[+] = HIVConcepts#HIV.I.DE2
-  * reasonForReferral from HIV.I.DE2
-* referralForOtherGeneralServices 0..1 string "Referral for other general services (specify)" "If none of the reasons above apply, specify the reason(s)"
+* reasonForReferral from HIV.I.DE2
+* referralForOtherGeneralServicesSpecify 0..1 string "Referral for other general services (specify)" "If none of the reasons above apply, specify the reason(s)"
   * ^code[+] = HIVConcepts#HIV.I.DE8
-* anyTreatmentGivenBeforeReferral? 1..1 boolean "Any treatment given before referral?" "If client was referred, was any treatment provided before referral?"
+* anyTreatmentGivenBeforeReferral 1..1 boolean "Any treatment given before referral?" "If client was referred, was any treatment provided before referral?"
   * ^code[+] = HIVConcepts#HIV.I.DE9
 * dateOfScheduledReferralAppointment 1..1 dateTime "Date of scheduled referral appointment" "When the referral is scheduled"
   * ^code[+] = HIVConcepts#HIV.I.DE10

--- a/input/fsh/models/HIVPrevention.fsh
+++ b/input/fsh/models/HIVPrevention.fsh
@@ -17,14 +17,14 @@ Description: "This tab describes the data that are collected during HIV preventi
   * ^code[+] = HIVConcepts#HIV.PRV.DE1
 * hivPreventionIntervention 0..* Coding "HIV prevention intervention" "HIV prevention intervention that client accessed"
   * ^code[+] = HIVConcepts#HIV.PRV.DE2
-  * hivPreventionIntervention from HIV.PRV.DE2
-* other 0..1 string "Other (specify)" "Client accessed other HIV prevention services (specify)"
+* hivPreventionIntervention from HIV.PRV.DE2
+* otherHivPreventionIntervention 0..1 string "Other (specify)" "Client accessed other HIV prevention services (specify)"
   * ^code[+] = HIVConcepts#HIV.PRV.DE9
 * dateAccessedHivPreventionIntervention 0..1 date "Date accessed HIV prevention intervention" "Date the client accessed HIV prevention intervention"
   * ^code[+] = HIVConcepts#HIV.PRV.DE10
 * hivStatusOfContact 0..1 Coding "HIV status of contact" "The HIV status of the client's contact"
   * ^code[+] = HIVConcepts#HIV.PRV.DE11
-  * hivStatusOfContact from HIV.PRV.DE11
+* hivStatusOfContact from HIV.PRV.DE11
 * dateInjectingEquipmentProvided 0..1 date "Date injecting equipment provided" "Date client was provided with injecting equipment"
   * ^code[+] = HIVConcepts#HIV.PRV.DE15
 * numberOfNeedlesSyringesProvided 0..1 integer "Number of needles-syringes provided" "Number of needles-syringes provided to client"
@@ -33,7 +33,7 @@ Description: "This tab describes the data that are collected during HIV preventi
   * ^code[+] = HIVConcepts#HIV.PRV.DE17
 * dateOamtDoseReceived 0..1 date "Date OAMT dose received" "Date client received opioid agonist maintenance treatment (OAMT) dose"
   * ^code[+] = HIVConcepts#HIV.PRV.DE18
-* dateOamtTakeAwayDos)Dispensed 0..1 date "Date OAMT take-away dose(s) dispensed" "Date the client was dispensed opioid agonist maintenance treatment (OAMT) take-away dose(s)"
+* dateOamtTakeAwayDosesDispensed 0..1 date "Date OAMT take-away dose(s) dispensed" "Date the client was dispensed opioid agonist maintenance treatment (OAMT) take-away dose(s)"
   * ^code[+] = HIVConcepts#HIV.PRV.DE19
 * currentlyOnOamt 0..1 boolean "Currently on OAMT" "Client is currently on opioid agonist maintenance treatment (OAMT) at reporting date, defined according to country/program to account for medication dispensed and LTFU criterion"
   * ^code[+] = HIVConcepts#HIV.PRV.DE20

--- a/input/fsh/valuesets/HIV.A.DE13.fsh
+++ b/input/fsh/valuesets/HIV.A.DE13.fsh
@@ -6,4 +6,4 @@ Description: "Value set of country where the client was born"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVADE13"

--- a/input/fsh/valuesets/HIV.A.DE18.fsh
+++ b/input/fsh/valuesets/HIV.A.DE18.fsh
@@ -6,6 +6,7 @@ Description: "Value set of gender of the client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVADE18"
 
 * HIVConcepts#HIV.A.DE19 "Female"
 * HIVConcepts#HIV.A.DE20 "Male"

--- a/input/fsh/valuesets/HIV.A.DE25.fsh
+++ b/input/fsh/valuesets/HIV.A.DE25.fsh
@@ -6,6 +6,7 @@ Description: "Value set of sex of the client assigned at birth"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVADE25"
 
 * HIVConcepts#HIV.A.DE26 "Female"
 * HIVConcepts#HIV.A.DE27 "Male"

--- a/input/fsh/valuesets/HIV.A.DE30.fsh
+++ b/input/fsh/valuesets/HIV.A.DE30.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's current marital status "
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVADE30"
 
 * HIVConcepts#HIV.A.DE31 "Unmarried"
 * HIVConcepts#HIV.A.DE32 "Never married"

--- a/input/fsh/valuesets/HIV.A.DE43.fsh
+++ b/input/fsh/valuesets/HIV.A.DE43.fsh
@@ -6,4 +6,4 @@ Description: "Value set of this should be a context-specific list of administrat
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVADE43"

--- a/input/fsh/valuesets/HIV.A.DE46.fsh
+++ b/input/fsh/valuesets/HIV.A.DE46.fsh
@@ -6,6 +6,7 @@ Description: "Value set of how the client would like to receive family planning 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVADE46"
 
 * HIVConcepts#HIV.A.DE47 "Text message/SMS"
 * HIVConcepts#HIV.A.DE48 "Voice call"

--- a/input/fsh/valuesets/HIV.A.DE5.fsh
+++ b/input/fsh/valuesets/HIV.A.DE5.fsh
@@ -6,6 +6,7 @@ Description: "Value set of how the client was referred"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVADE5"
 
 * HIVConcepts#HIV.A.DE6 "Community"
 * HIVConcepts#HIV.A.DE7 "Facility"

--- a/input/fsh/valuesets/HIV.B.DE1.fsh
+++ b/input/fsh/valuesets/HIV.B.DE1.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason for HIV testing services visit"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE1"
 
 * HIVConcepts#HIV.B.DE2 "First-time HIV test"
 * HIVConcepts#HIV.B.DE3 "Retesting for HIV"

--- a/input/fsh/valuesets/HIV.B.DE102.fsh
+++ b/input/fsh/valuesets/HIV.B.DE102.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the third HIV assay in the testing stra
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE102"
 
 * HIVConcepts#HIV.B.DE103 "Reactive"
 * HIVConcepts#HIV.B.DE104 "Non-reactive"

--- a/input/fsh/valuesets/HIV.B.DE106.fsh
+++ b/input/fsh/valuesets/HIV.B.DE106.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the repeated first HIV assay in the tes
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE106"
 
 * HIVConcepts#HIV.B.DE107 "Reactive"
 * HIVConcepts#HIV.B.DE108 "Non-reactive"

--- a/input/fsh/valuesets/HIV.B.DE111.fsh
+++ b/input/fsh/valuesets/HIV.B.DE111.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result from HIV testing after applying the testin
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE111"
 
 * HIVConcepts#HIV.B.DE112 "HIV-positive"
 * HIVConcepts#HIV.B.DE113 "HIV-negative"

--- a/input/fsh/valuesets/HIV.B.DE115.fsh
+++ b/input/fsh/valuesets/HIV.B.DE115.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV status reported after applying the national HIV t
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE115"
 
 * HIVConcepts#HIV.B.DE116 "HIV-positive"
 * HIVConcepts#HIV.B.DE117 "HIV-negative"

--- a/input/fsh/valuesets/HIV.B.DE120.fsh
+++ b/input/fsh/valuesets/HIV.B.DE120.fsh
@@ -6,4 +6,4 @@ Description: "Value set of name or identifier of health facility where HIV test 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVBDE120"

--- a/input/fsh/valuesets/HIV.B.DE121.fsh
+++ b/input/fsh/valuesets/HIV.B.DE121.fsh
@@ -6,6 +6,7 @@ Description: "Value set of probable route(s) of transmission of HIV to client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE121"
 
 * HIVConcepts#HIV.B.DE122 "Heterosexual sex"
 * HIVConcepts#HIV.B.DE123 "Sex between men"

--- a/input/fsh/valuesets/HIV.B.DE132.fsh
+++ b/input/fsh/valuesets/HIV.B.DE132.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV test result of the client's partner"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE132"
 
 * HIVConcepts#HIV.B.DE133 "HIV-positive"
 * HIVConcepts#HIV.B.DE134 "HIV-negative"

--- a/input/fsh/valuesets/HIV.B.DE136.fsh
+++ b/input/fsh/valuesets/HIV.B.DE136.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV status of a sexual or drug-injecting partner 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE136"
 
 * HIVConcepts#HIV.B.DE137 "HIV-positive"
 * HIVConcepts#HIV.B.DE138 "HIV-negative"

--- a/input/fsh/valuesets/HIV.B.DE142.fsh
+++ b/input/fsh/valuesets/HIV.B.DE142.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether counselling was provided to a client during t
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE142"
 
 * HIVConcepts#HIV.B.DE143 "HIV-positive counselling conducted"
 * HIVConcepts#HIV.B.DE144 "Hepatitis B positive counselling conducted"

--- a/input/fsh/valuesets/HIV.B.DE149.fsh
+++ b/input/fsh/valuesets/HIV.B.DE149.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer to prevention services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE149"
 
 * HIVConcepts#HIV.B.DE150 "Offer male and female condoms and condom-compatible lubricants"
 * HIVConcepts#HIV.B.DE151 "Offer pre-exposure prophylaxis (PrEP) for people at elevated risk for HIV acquisition"

--- a/input/fsh/valuesets/HIV.B.DE15.fsh
+++ b/input/fsh/valuesets/HIV.B.DE15.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether testing is happening in the community or at a
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE15"
 
 * HIVConcepts#HIV.B.DE16 "Community-level testing"
 * HIVConcepts#HIV.B.DE17 "Facility-level testing"

--- a/input/fsh/valuesets/HIV.B.DE158.fsh
+++ b/input/fsh/valuesets/HIV.B.DE158.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer to sexual and reproductive health serv
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE158"
 
 * HIVConcepts#HIV.B.DE159 "Contraception and family planning"
 * HIVConcepts#HIV.B.DE160 "Check pregnancy status"

--- a/input/fsh/valuesets/HIV.B.DE165.fsh
+++ b/input/fsh/valuesets/HIV.B.DE165.fsh
@@ -6,6 +6,7 @@ Description: "Value set of other clinical services offered or referrals given to
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE165"
 
 * HIVConcepts#HIV.B.DE166 "Assessment and provision of vaccinations"
 * HIVConcepts#HIV.B.DE167 "Hepatitis B (HBV) and hepatitis C virus (HCV) testing and treatment provided"

--- a/input/fsh/valuesets/HIV.B.DE172.fsh
+++ b/input/fsh/valuesets/HIV.B.DE172.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer for other support services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE172"
 
 * HIVConcepts#HIV.B.DE173 "Mental health services"
 * HIVConcepts#HIV.B.DE174 "Psychosocial counselling, support and treatment adherence counselling"

--- a/input/fsh/valuesets/HIV.B.DE179.fsh
+++ b/input/fsh/valuesets/HIV.B.DE179.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result of medical inquiry for intimate partner violen
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE179"
 
 * HIVConcepts#HIV.B.DE180 "Client received treatment and/or counselling as needed"
 * HIVConcepts#HIV.B.DE181 "Client was referred"

--- a/input/fsh/valuesets/HIV.B.DE18.fsh
+++ b/input/fsh/valuesets/HIV.B.DE18.fsh
@@ -6,6 +6,7 @@ Description: "Value set of specific point in the community where testing is happ
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE18"
 
 * HIVConcepts#HIV.B.DE19 "Mobile testing (e.g. through vans or temporary testing facilities)"
 * HIVConcepts#HIV.B.DE20 "Voluntary counselling and testing centres (not within a health facility setting)"

--- a/input/fsh/valuesets/HIV.B.DE191.fsh
+++ b/input/fsh/valuesets/HIV.B.DE191.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of follow-up appointment for testing services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE191"
 
 * HIVConcepts#HIV.B.DE192 "Retesting for HIV"
 * HIVConcepts#HIV.B.DE193 "Other"

--- a/input/fsh/valuesets/HIV.B.DE201.fsh
+++ b/input/fsh/valuesets/HIV.B.DE201.fsh
@@ -6,4 +6,4 @@ Description: "Value set of severity of the adverse event associated with volunta
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVBDE201"

--- a/input/fsh/valuesets/HIV.B.DE204.fsh
+++ b/input/fsh/valuesets/HIV.B.DE204.fsh
@@ -6,6 +6,7 @@ Description: "Value set of when the adverse event associated with VMMC procedure
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE204"
 
 * HIVConcepts#HIV.B.DE205 "Intraoperative"
 * HIVConcepts#HIV.B.DE206 "Postoperative"

--- a/input/fsh/valuesets/HIV.B.DE207.fsh
+++ b/input/fsh/valuesets/HIV.B.DE207.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of adverse event associated with voluntary medic
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE207"
 
 * HIVConcepts#HIV.B.DE208 "Abnormal pain"
 * HIVConcepts#HIV.B.DE209 "Anaesthesia-related effects"

--- a/input/fsh/valuesets/HIV.B.DE22.fsh
+++ b/input/fsh/valuesets/HIV.B.DE22.fsh
@@ -6,6 +6,7 @@ Description: "Value set of specific point where testing is happening at a facili
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE22"
 
 * HIVConcepts#HIV.B.DE23 "Provider-initiated tested in a clinic or emergency facility"
 * HIVConcepts#HIV.B.DE24 "Antenatal care clinic"

--- a/input/fsh/valuesets/HIV.B.DE226.fsh
+++ b/input/fsh/valuesets/HIV.B.DE226.fsh
@@ -6,6 +6,7 @@ Description: "Value set of syndrome or STI for which client is diagnosed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE226"
 
 * HIVConcepts#HIV.B.DE227 "Urethral discharge syndrome"
 * HIVConcepts#HIV.B.DE228 "Vaginal discharge syndrome"

--- a/input/fsh/valuesets/HIV.B.DE237.fsh
+++ b/input/fsh/valuesets/HIV.B.DE237.fsh
@@ -6,6 +6,7 @@ Description: "Value set of sTI for which the client was tested"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE237"
 
 * HIVConcepts#HIV.B.DE238 "Neisseria gonorrhoeae"
 * HIVConcepts#HIV.B.DE239 "Chlamydia trachomatis"

--- a/input/fsh/valuesets/HIV.B.DE250.fsh
+++ b/input/fsh/valuesets/HIV.B.DE250.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE250"
 
 * HIVConcepts#HIV.B.DE251 "Positive"
 * HIVConcepts#HIV.B.DE252 "Negative"

--- a/input/fsh/valuesets/HIV.B.DE256.fsh
+++ b/input/fsh/valuesets/HIV.B.DE256.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from Gonorrhoea test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE256"
 
 * HIVConcepts#HIV.B.DE257 "Positive"
 * HIVConcepts#HIV.B.DE258 "Negative"

--- a/input/fsh/valuesets/HIV.B.DE261.fsh
+++ b/input/fsh/valuesets/HIV.B.DE261.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of specimen to be collected"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE261"
 
 * HIVConcepts#HIV.B.DE262 "Blood"
 * HIVConcepts#HIV.B.DE263 "Urine"

--- a/input/fsh/valuesets/HIV.B.DE269.fsh
+++ b/input/fsh/valuesets/HIV.B.DE269.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for syphilis (treponema 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE269"
 
 * HIVConcepts#HIV.B.DE270 "Treponemal"
 * HIVConcepts#HIV.B.DE271 "Non-treponemal"

--- a/input/fsh/valuesets/HIV.B.DE276.fsh
+++ b/input/fsh/valuesets/HIV.B.DE276.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Neisseria gonorrhoea
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE276"
 
 * HIVConcepts#HIV.B.DE277 "NAAT"
 * HIVConcepts#HIV.B.DE278 "POC Test"

--- a/input/fsh/valuesets/HIV.B.DE284.fsh
+++ b/input/fsh/valuesets/HIV.B.DE284.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Chlamydia trachomati
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE284"
 
 * HIVConcepts#HIV.B.DE285 "NAAT"
 * HIVConcepts#HIV.B.DE286 "POC Test"

--- a/input/fsh/valuesets/HIV.B.DE293.fsh
+++ b/input/fsh/valuesets/HIV.B.DE293.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Trichomonas vaginali
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE293"
 
 * HIVConcepts#HIV.B.DE294 "NAAT"
 * HIVConcepts#HIV.B.DE295 "POC Test"

--- a/input/fsh/valuesets/HIV.B.DE301.fsh
+++ b/input/fsh/valuesets/HIV.B.DE301.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for herpes simplex virus
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE301"
 
 * HIVConcepts#HIV.B.DE302 "NAAT"
 * HIVConcepts#HIV.B.DE303 "Antibody test"

--- a/input/fsh/valuesets/HIV.B.DE306.fsh
+++ b/input/fsh/valuesets/HIV.B.DE306.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Mycoplasma genitaliu
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE306"
 
 * HIVConcepts#HIV.B.DE307 "NAAT"
 * HIVConcepts#HIV.B.DE308 "Microscopy"

--- a/input/fsh/valuesets/HIV.B.DE312.fsh
+++ b/input/fsh/valuesets/HIV.B.DE312.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from STI test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE312"
 
 * HIVConcepts#HIV.B.DE313 "Positive"
 * HIVConcepts#HIV.B.DE314 "Negative"

--- a/input/fsh/valuesets/HIV.B.DE317.fsh
+++ b/input/fsh/valuesets/HIV.B.DE317.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of test ued for confirmatory syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE317"
 
 * HIVConcepts#HIV.B.DE318 "Treponemal"
 * HIVConcepts#HIV.B.DE319 "Non-treponemal"

--- a/input/fsh/valuesets/HIV.B.DE325.fsh
+++ b/input/fsh/valuesets/HIV.B.DE325.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from confirmatory STI test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE325"
 
 * HIVConcepts#HIV.B.DE326 "Positive"
 * HIVConcepts#HIV.B.DE327 "Negative"

--- a/input/fsh/valuesets/HIV.B.DE33.fsh
+++ b/input/fsh/valuesets/HIV.B.DE33.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV status of the client's partner."
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE33"
 
 * HIVConcepts#HIV.B.DE34 "HIV-positive"
 * HIVConcepts#HIV.B.DE35 "HIV-negative"

--- a/input/fsh/valuesets/HIV.B.DE37.fsh
+++ b/input/fsh/valuesets/HIV.B.DE37.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's partner is a member of a key population, tha
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE37"
 
 * HIVConcepts#HIV.B.DE38 "Sex worker"
 * HIVConcepts#HIV.B.DE39 "Men who have sex with men"

--- a/input/fsh/valuesets/HIV.B.DE44.fsh
+++ b/input/fsh/valuesets/HIV.B.DE44.fsh
@@ -6,4 +6,4 @@ Description: "Value set of results from the reported HIV self-test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVBDE44"

--- a/input/fsh/valuesets/HIV.B.DE5.fsh
+++ b/input/fsh/valuesets/HIV.B.DE5.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client reported coming to the facility after receivin
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE5"
 
 * HIVConcepts#HIV.B.DE6 "Partner or contact of an index case"
 * HIVConcepts#HIV.B.DE7 "Partner or contact of an HIV testing client (non-index case)"

--- a/input/fsh/valuesets/HIV.B.DE50.fsh
+++ b/input/fsh/valuesets/HIV.B.DE50.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the type of key population that the client is include
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE50"
 
 * HIVConcepts#HIV.B.DE51 "Sex worker"
 * HIVConcepts#HIV.B.DE52 "Men who have sex with men"

--- a/input/fsh/valuesets/HIV.B.DE61.fsh
+++ b/input/fsh/valuesets/HIV.B.DE61.fsh
@@ -6,6 +6,7 @@ Description: "Value set of ways in which the client was exposed to HIV"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE61"
 
 * HIVConcepts#HIV.B.DE62 "Occupational"
 * HIVConcepts#HIV.B.DE63 "Non-occupational violent"

--- a/input/fsh/valuesets/HIV.B.DE66.fsh
+++ b/input/fsh/valuesets/HIV.B.DE66.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.B.DE66
+Title: "HIV diagnosing facility ValueSet"
+Description: "Value set of the facility where the client received an HIV-positive diagnosis"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVBDE66"

--- a/input/fsh/valuesets/HIV.B.DE68.fsh
+++ b/input/fsh/valuesets/HIV.B.DE68.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the client's HIV serotype"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE68"
 
 * HIVConcepts#HIV.B.DE69 "HIV-1"
 * HIVConcepts#HIV.B.DE70 "HIV-2"

--- a/input/fsh/valuesets/HIV.B.DE74.fsh
+++ b/input/fsh/valuesets/HIV.B.DE74.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's relationship to the contact identified for v
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE74"
 
 * HIVConcepts#HIV.B.DE75 "Biological child"
 * HIVConcepts#HIV.B.DE76 "Drug-injecting partner"

--- a/input/fsh/valuesets/HIV.B.DE8.fsh
+++ b/input/fsh/valuesets/HIV.B.DE8.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's relationship to the person that referred the
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE8"
 
 * HIVConcepts#HIV.B.DE9 "Biological child"
 * HIVConcepts#HIV.B.DE10 "Drug-injecting partner"

--- a/input/fsh/valuesets/HIV.B.DE81.fsh
+++ b/input/fsh/valuesets/HIV.B.DE81.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of HIV test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE81"
 
 * HIVConcepts#HIV.B.DE82 "Rapid diagnostic test for HIV"
 * HIVConcepts#HIV.B.DE83 "Enzyme immunoassay for HIV"

--- a/input/fsh/valuesets/HIV.B.DE88.fsh
+++ b/input/fsh/valuesets/HIV.B.DE88.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the number of the assay (test kit) in the HIV testing
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVBDE88"

--- a/input/fsh/valuesets/HIV.B.DE94.fsh
+++ b/input/fsh/valuesets/HIV.B.DE94.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the first HIV assay in the testing stra
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE94"
 
 * HIVConcepts#HIV.B.DE95 "Reactive"
 * HIVConcepts#HIV.B.DE96 "Non-reactive"

--- a/input/fsh/valuesets/HIV.B.DE98.fsh
+++ b/input/fsh/valuesets/HIV.B.DE98.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the second HIV assay in the testing str
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVBDE98"
 
 * HIVConcepts#HIV.B.DE99 "Reactive"
 * HIVConcepts#HIV.B.DE100 "Non-reactive"

--- a/input/fsh/valuesets/HIV.C.DE1.fsh
+++ b/input/fsh/valuesets/HIV.C.DE1.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's reason for the prevention visit"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE1"
 
 * HIVConcepts#HIV.C.DE2 "First time counselling on PrEP"
 * HIVConcepts#HIV.C.DE3 "Follow-up appointment for PrEP or PEP"

--- a/input/fsh/valuesets/HIV.C.DE101.fsh
+++ b/input/fsh/valuesets/HIV.C.DE101.fsh
@@ -6,10 +6,9 @@ Description: "Value set of alternative third drug for PEP"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE101"
 
 * HIVConcepts#HIV.C.DE102 "ATV/r"
 * HIVConcepts#HIV.C.DE103 "DRV/r"
 * HIVConcepts#HIV.C.DE104 "LPV/r"
 * HIVConcepts#HIV.C.DE105 "RAL"
-* HIVConcepts#HIV.C.DE108 "Male"
-* HIVConcepts#HIV.C.DE109 "Female"

--- a/input/fsh/valuesets/HIV.C.DE107.fsh
+++ b/input/fsh/valuesets/HIV.C.DE107.fsh
@@ -1,0 +1,12 @@
+ValueSet: HIV.C.DE107
+Title: "Sex factor for estimating creatinine clearance ValueSet"
+Description: "Value set of value used for gender for calculating creatinine clearance if required. For transgender populations, the sex at birth is used in the Cockcroft-Gault equation if the person is not using hormone therapy; among transgender populations using hormone therapy for more than three months, the current gender can be used."
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVCDE107"
+
+* HIVConcepts#HIV.C.DE108 "Male"
+* HIVConcepts#HIV.C.DE109 "Female"

--- a/input/fsh/valuesets/HIV.C.DE11.fsh
+++ b/input/fsh/valuesets/HIV.C.DE11.fsh
@@ -6,6 +6,7 @@ Description: "Value set of way in which pre-exposure prophylaxis (PrEP) is taken
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE11"
 
 * HIVConcepts#HIV.C.DE12 "Daily oral PrEP"
 * HIVConcepts#HIV.C.DE13 "Event-driven PrEP (2+1+1)"

--- a/input/fsh/valuesets/HIV.C.DE112.fsh
+++ b/input/fsh/valuesets/HIV.C.DE112.fsh
@@ -6,6 +6,7 @@ Description: "Value set of listing of contraindications to pre-exposure prophyla
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE112"
 
 * HIVConcepts#HIV.C.DE113 "Tenofovir disoproxil fumarate (TDF) allergy or contraindication"
 * HIVConcepts#HIV.C.DE114 "HIV-positive"

--- a/input/fsh/valuesets/HIV.C.DE122.fsh
+++ b/input/fsh/valuesets/HIV.C.DE122.fsh
@@ -6,4 +6,4 @@ Description: "Value set of HIV pre-exposure prophylaxis (PrEP) regimen prescribe
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVCDE122"

--- a/input/fsh/valuesets/HIV.C.DE125.fsh
+++ b/input/fsh/valuesets/HIV.C.DE125.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of follow-up appointment for testing services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE125"
 
 * HIVConcepts#HIV.C.DE126 "Retesting for HIV"
 * HIVConcepts#HIV.C.DE127 "Follow-up appointment for PrEP"

--- a/input/fsh/valuesets/HIV.C.DE131.fsh
+++ b/input/fsh/valuesets/HIV.C.DE131.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer to prevention services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE131"
 
 * HIVConcepts#HIV.C.DE132 "Male and female condoms and condom-compatible lubricants offered"
 * HIVConcepts#HIV.C.DE133 "Voluntary medical male circumcision (VMMC) referral"

--- a/input/fsh/valuesets/HIV.C.DE138.fsh
+++ b/input/fsh/valuesets/HIV.C.DE138.fsh
@@ -6,11 +6,7 @@ Description: "Value set of type of condom provided to client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE138"
 
 * HIVConcepts#HIV.C.DE139 "Male condom"
 * HIVConcepts#HIV.C.DE140 "Female condom"
-* HIVConcepts#HIV.C.DE144 "Self"
-* HIVConcepts#HIV.C.DE145 "Family member"
-* HIVConcepts#HIV.C.DE146 "Drug-injecting partner"
-* HIVConcepts#HIV.C.DE147 "Sexual partner"
-* HIVConcepts#HIV.C.DE148 "Social contact"

--- a/input/fsh/valuesets/HIV.C.DE143.fsh
+++ b/input/fsh/valuesets/HIV.C.DE143.fsh
@@ -1,0 +1,15 @@
+ValueSet: HIV.C.DE143
+Title: "HIV self-test distributed for use by ValueSet"
+Description: "Value set of whom the client plans to give the HIV self-test kit (self, sexual partner, social contact, etc.)"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVCDE143"
+
+* HIVConcepts#HIV.C.DE144 "Self"
+* HIVConcepts#HIV.C.DE145 "Family member"
+* HIVConcepts#HIV.C.DE146 "Drug-injecting partner"
+* HIVConcepts#HIV.C.DE147 "Sexual partner"
+* HIVConcepts#HIV.C.DE148 "Social contact"

--- a/input/fsh/valuesets/HIV.C.DE149.fsh
+++ b/input/fsh/valuesets/HIV.C.DE149.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer to sexual and reproductive health serv
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE149"
 
 * HIVConcepts#HIV.C.DE150 "Contraception and family planning"
 * HIVConcepts#HIV.C.DE151 "Check pregnancy status"

--- a/input/fsh/valuesets/HIV.C.DE157.fsh
+++ b/input/fsh/valuesets/HIV.C.DE157.fsh
@@ -6,6 +6,7 @@ Description: "Value set of other clinical services offered or referrals given to
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE157"
 
 * HIVConcepts#HIV.C.DE158 "Assessment and provision of vaccinations"
 * HIVConcepts#HIV.C.DE159 "Hepatitis B virus (HBV) and hepatitis C virus (HCV) testing and treatment"

--- a/input/fsh/valuesets/HIV.C.DE164.fsh
+++ b/input/fsh/valuesets/HIV.C.DE164.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer for other support services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE164"
 
 * HIVConcepts#HIV.C.DE165 "Mental health services"
 * HIVConcepts#HIV.C.DE166 "Psychosocial counselling, support and treatment adherence counselling"

--- a/input/fsh/valuesets/HIV.C.DE17.fsh
+++ b/input/fsh/valuesets/HIV.C.DE17.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV pre-exposure prophylaxis (PrEP) regimen"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE17"
 
 * HIVConcepts#HIV.C.DE18 "TDF + FTC"
 * HIVConcepts#HIV.C.DE19 "TDF"

--- a/input/fsh/valuesets/HIV.C.DE24.fsh
+++ b/input/fsh/valuesets/HIV.C.DE24.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the client's experience in taking PrEP"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE24"
 
 * HIVConcepts#HIV.C.DE25 "First-time user"
 * HIVConcepts#HIV.C.DE26 "Continuing user"

--- a/input/fsh/valuesets/HIV.C.DE31.fsh
+++ b/input/fsh/valuesets/HIV.C.DE31.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the client's history in taking post-exposure prophyla
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE31"
 
 * HIVConcepts#HIV.C.DE32 "First-time user"
 * HIVConcepts#HIV.C.DE33 "Repeat user"

--- a/input/fsh/valuesets/HIV.C.DE36.fsh
+++ b/input/fsh/valuesets/HIV.C.DE36.fsh
@@ -6,6 +6,7 @@ Description: "Value set of signs the client is at a substantial risk of HIV infe
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE36"
 
 * HIVConcepts#HIV.C.DE37 "No condom use during sex with more than one partner in the past 6 months"
 * HIVConcepts#HIV.C.DE38 "STI in the past 6 months"

--- a/input/fsh/valuesets/HIV.C.DE41.fsh
+++ b/input/fsh/valuesets/HIV.C.DE41.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's intention or desire in the next year to eith
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE41"
 
 * HIVConcepts#HIV.C.DE42 "Yes, I want to become pregnant"
 * HIVConcepts#HIV.C.DE43 "I'm OK either way"

--- a/input/fsh/valuesets/HIV.C.DE46.fsh
+++ b/input/fsh/valuesets/HIV.C.DE46.fsh
@@ -6,6 +6,7 @@ Description: "Value set of symptoms that could suggest an acute HIV infection"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE46"
 
 * HIVConcepts#HIV.C.DE47 "Fever"
 * HIVConcepts#HIV.C.DE48 "Sore throat"

--- a/input/fsh/valuesets/HIV.C.DE55.fsh
+++ b/input/fsh/valuesets/HIV.C.DE55.fsh
@@ -6,6 +6,7 @@ Description: "Value set of treatment adherence of client's sex partner for partn
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE55"
 
 * HIVConcepts#HIV.C.DE56 "Not on ART"
 * HIVConcepts#HIV.C.DE57 "On ART less than 6 months"

--- a/input/fsh/valuesets/HIV.C.DE63.fsh
+++ b/input/fsh/valuesets/HIV.C.DE63.fsh
@@ -6,6 +6,7 @@ Description: "Value set of listing of tests for clients on or starting pre-expos
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE63"
 
 * HIVConcepts#HIV.C.DE64 "Serum creatinine test"
 * HIVConcepts#HIV.C.DE65 "Hepatitis B test"

--- a/input/fsh/valuesets/HIV.C.DE75.fsh
+++ b/input/fsh/valuesets/HIV.C.DE75.fsh
@@ -6,6 +6,7 @@ Description: "Value set of medications the client was prescribed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE75"
 
 * HIVConcepts#HIV.C.DE76 "PrEP for HIV prevention"
 * HIVConcepts#HIV.C.DE77 "PEP for HIV prevention"

--- a/input/fsh/valuesets/HIV.C.DE80.fsh
+++ b/input/fsh/valuesets/HIV.C.DE80.fsh
@@ -6,6 +6,7 @@ Description: "Value set of prEP product that the client was prescribed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE80"
 
 * HIVConcepts#HIV.C.DE81 "Oral PrEP"
 * HIVConcepts#HIV.C.DE82 "Dapivirine vaginal ring (DVR)"

--- a/input/fsh/valuesets/HIV.C.DE91.fsh
+++ b/input/fsh/valuesets/HIV.C.DE91.fsh
@@ -6,6 +6,7 @@ Description: "Value set of preferred backbone regimen for PEP"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE91"
 
 * HIVConcepts#HIV.C.DE92 "TDF + 3TC"
 * HIVConcepts#HIV.C.DE93 "TDF + FTC"

--- a/input/fsh/valuesets/HIV.C.DE95.fsh
+++ b/input/fsh/valuesets/HIV.C.DE95.fsh
@@ -6,6 +6,7 @@ Description: "Value set of alternative backbone regimen for PEP"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE95"
 
 * HIVConcepts#HIV.C.DE96 "ABC + 3TC"
 * HIVConcepts#HIV.C.DE97 "TDF + 3TC"

--- a/input/fsh/valuesets/HIV.C.DE99.fsh
+++ b/input/fsh/valuesets/HIV.C.DE99.fsh
@@ -6,5 +6,6 @@ Description: "Value set of preferred third drug for PEP"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVCDE99"
 
 * HIVConcepts#HIV.C.DE100 "DTG"

--- a/input/fsh/valuesets/HIV.Config.DE12.fsh
+++ b/input/fsh/valuesets/HIV.Config.DE12.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV burden of the setting (high or low) based on the 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVConfigDE12"
 
 * HIVConcepts#HIV.Config.DE13 "High HIV burden setting"
 * HIVConcepts#HIV.Config.DE14 "Low HIV burden setting"

--- a/input/fsh/valuesets/HIV.Config.DE19.fsh
+++ b/input/fsh/valuesets/HIV.Config.DE19.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.Config.DE19
+Title: "Other priority populations ValueSet"
+Description: "Value set of other populations of priority of HIV prevention and care in local context (provided during adaptation)"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVConfigDE19"

--- a/input/fsh/valuesets/HIV.D.DE1.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether visit was scheduled or unscheduled, clinical 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE1"
 
 * HIVConcepts#HIV.D.DE2 "First clinical visit"
 * HIVConcepts#HIV.D.DE3 "Clinical visit"

--- a/input/fsh/valuesets/HIV.D.DE1002.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1002.fsh
@@ -6,6 +6,7 @@ Description: "Value set of indicates patient's TB treatment outcome"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE1002"
 
 * HIVConcepts#HIV.D.DE1003 "Treatment failed"
 * HIVConcepts#HIV.D.DE1004 "Cured"

--- a/input/fsh/valuesets/HIV.D.DE1010.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1010.fsh
@@ -6,6 +6,7 @@ Description: "Value set of tB drugs currently being taken by the client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE1010"
 
 * HIVConcepts#HIV.D.DE1011 "Isoniazid"
 * HIVConcepts#HIV.D.DE1012 "Rifampicin"
@@ -13,6 +14,3 @@ Description: "Value set of tB drugs currently being taken by the client"
 * HIVConcepts#HIV.D.DE1014 "Ethambutol"
 * HIVConcepts#HIV.D.DE1015 "Levofloxacin"
 * HIVConcepts#HIV.D.DE1016 "Pyrazinamide"
-* HIVConcepts#HIV.D.DE1020 "Symptomatic for TB"
-* HIVConcepts#HIV.D.DE1021 "Diagnosed TB"
-* HIVConcepts#HIV.D.DE1022 ""

--- a/input/fsh/valuesets/HIV.D.DE1019.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1019.fsh
@@ -1,0 +1,13 @@
+ValueSet: HIV.D.DE1019
+Title: "TB status at ART start ValueSet"
+Description: "Value set of client's tuberculosis (TB) status when antiretroviral therapy (ART) is started"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE1019"
+
+* HIVConcepts#HIV.D.DE1020 "Symptomatic for TB"
+* HIVConcepts#HIV.D.DE1021 "Diagnosed TB"
+* HIVConcepts#HIV.D.DE1022 ""

--- a/input/fsh/valuesets/HIV.D.DE1028.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1028.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of TPT regimen the client is currently on"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE1028"
 
 * HIVConcepts#HIV.D.DE1029 "3HP"
 * HIVConcepts#HIV.D.DE1030 "1HP"

--- a/input/fsh/valuesets/HIV.D.DE1034.fsh
+++ b/input/fsh/valuesets/HIV.D.DE1034.fsh
@@ -6,6 +6,7 @@ Description: "Value set of indicates the current status of TB preventive treatme
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE1034"
 
 * HIVConcepts#HIV.D.DE1035 "Not started"
 * HIVConcepts#HIV.D.DE1036 "On TPT"

--- a/input/fsh/valuesets/HIV.D.DE128.fsh
+++ b/input/fsh/valuesets/HIV.D.DE128.fsh
@@ -6,6 +6,7 @@ Description: "Value set of drug composition of client's current ART regimen"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE128"
 
 * HIVConcepts#HIV.D.DE129 "ABC"
 * HIVConcepts#HIV.D.DE130 "FTC"

--- a/input/fsh/valuesets/HIV.D.DE146.fsh
+++ b/input/fsh/valuesets/HIV.D.DE146.fsh
@@ -6,6 +6,7 @@ Description: "Value set of drug class of current ART regimen"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE146"
 
 * HIVConcepts#HIV.D.DE147 "NRTI"
 * HIVConcepts#HIV.D.DE148 "NtRTI"

--- a/input/fsh/valuesets/HIV.D.DE152.fsh
+++ b/input/fsh/valuesets/HIV.D.DE152.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer for prevention services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE152"
 
 * HIVConcepts#HIV.D.DE153 "Offer male and female condoms and condom-compatible lubricants"
 * HIVConcepts#HIV.D.DE154 "Harm reduction for people who inject drugs"

--- a/input/fsh/valuesets/HIV.D.DE156.fsh
+++ b/input/fsh/valuesets/HIV.D.DE156.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer to sexual and reproductive health serv
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE156"
 
 * HIVConcepts#HIV.D.DE157 "Contraception and family planning"
 * HIVConcepts#HIV.D.DE158 "Check pregnancy status"

--- a/input/fsh/valuesets/HIV.D.DE162.fsh
+++ b/input/fsh/valuesets/HIV.D.DE162.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis B virus test result (HBsAg)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE162"
 
 * HIVConcepts#HIV.D.DE163 "Positive"
 * HIVConcepts#HIV.D.DE164 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE168.fsh
+++ b/input/fsh/valuesets/HIV.D.DE168.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE168
+Title: "HBV treatment regimen prescribed ValueSet"
+Description: "Value set of hepatitis B virus treatment regimen prescribed"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE168"

--- a/input/fsh/valuesets/HIV.D.DE17.fsh
+++ b/input/fsh/valuesets/HIV.D.DE17.fsh
@@ -6,6 +6,7 @@ Description: "Value set of signs that may indicate the client has a serious illn
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE17"
 
 * HIVConcepts#HIV.D.DE18 "Fever of 39 C or greater"
 * HIVConcepts#HIV.D.DE19 "Tachycardia"

--- a/input/fsh/valuesets/HIV.D.DE170.fsh
+++ b/input/fsh/valuesets/HIV.D.DE170.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis C virus test result (HCV antibody, HCV RNA 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE170"
 
 * HIVConcepts#HIV.D.DE171 "Positive"
 * HIVConcepts#HIV.D.DE172 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE177.fsh
+++ b/input/fsh/valuesets/HIV.D.DE177.fsh
@@ -6,4 +6,4 @@ Description: "Value set of hepatitis C virus treatment regimen prescribed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE177"

--- a/input/fsh/valuesets/HIV.D.DE179.fsh
+++ b/input/fsh/valuesets/HIV.D.DE179.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis C viral load test result (qualitative)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE179"
 
 * HIVConcepts#HIV.D.DE180 "Detected"
 * HIVConcepts#HIV.D.DE181 "Not detected"

--- a/input/fsh/valuesets/HIV.D.DE182.fsh
+++ b/input/fsh/valuesets/HIV.D.DE182.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of medicine client is prescribed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE182"
 
 * HIVConcepts#HIV.D.DE183 "Interferon"
 * HIVConcepts#HIV.D.DE184 "Direct acting antivirals"

--- a/input/fsh/valuesets/HIV.D.DE186.fsh
+++ b/input/fsh/valuesets/HIV.D.DE186.fsh
@@ -6,6 +6,7 @@ Description: "Value set of wHO clinical stage of client based on signs and sympt
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE186"
 
 * HIVConcepts#HIV.D.DE187 "WHO HIV clinical stage 1"
 * HIVConcepts#HIV.D.DE188 "WHO HIV clinical stage 2"

--- a/input/fsh/valuesets/HIV.D.DE197.fsh
+++ b/input/fsh/valuesets/HIV.D.DE197.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why client was not adherent"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE197"
 
 * HIVConcepts#HIV.D.DE198 "Forgot"
 * HIVConcepts#HIV.D.DE199 "Toxicity/side effects"

--- a/input/fsh/valuesets/HIV.D.DE217.fsh
+++ b/input/fsh/valuesets/HIV.D.DE217.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason client intentionally stopped ART"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE217"
 
 * HIVConcepts#HIV.D.DE218 "Toxicity/side effects"
 * HIVConcepts#HIV.D.DE219 "Severe illness, hospitalization"

--- a/input/fsh/valuesets/HIV.D.DE225.fsh
+++ b/input/fsh/valuesets/HIV.D.DE225.fsh
@@ -6,6 +6,7 @@ Description: "Value set of aRT treatment failure"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE225"
 
 * HIVConcepts#HIV.D.DE226 "Clinical failure"
 * HIVConcepts#HIV.D.DE227 "Immunological failure"

--- a/input/fsh/valuesets/HIV.D.DE229.fsh
+++ b/input/fsh/valuesets/HIV.D.DE229.fsh
@@ -6,6 +6,7 @@ Description: "Value set of general care activities to be performed during the ca
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE229"
 
 * HIVConcepts#HIV.D.DE230 "Determine WHO clinical stage"
 * HIVConcepts#HIV.D.DE231 "Determine if advanced disease"

--- a/input/fsh/valuesets/HIV.D.DE247.fsh
+++ b/input/fsh/valuesets/HIV.D.DE247.fsh
@@ -6,6 +6,7 @@ Description: "Value set of coinfection prevention and treatment activities perfo
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE247"
 
 * HIVConcepts#HIV.D.DE248 "Provide co-trimoxazole preventive therapy (CPT)"
 * HIVConcepts#HIV.D.DE249 "Intensified TB case finding and linkage to TB treatment"

--- a/input/fsh/valuesets/HIV.D.DE259.fsh
+++ b/input/fsh/valuesets/HIV.D.DE259.fsh
@@ -6,6 +6,7 @@ Description: "Value set of signs and symptoms of opportunistic infections or oth
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE259"
 
 * HIVConcepts#HIV.D.DE260 "Oral candidiasis"
 * HIVConcepts#HIV.D.DE261 "Vaginal candidiasis"

--- a/input/fsh/valuesets/HIV.D.DE289.fsh
+++ b/input/fsh/valuesets/HIV.D.DE289.fsh
@@ -6,6 +6,7 @@ Description: "Value set of new or recurrent clinical events used to categorize H
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE289"
 
 * HIVConcepts#HIV.D.DE290 "Asymptomatic"
 * HIVConcepts#HIV.D.DE291 "Persistent generalized lymphadenopathy"

--- a/input/fsh/valuesets/HIV.D.DE358.fsh
+++ b/input/fsh/valuesets/HIV.D.DE358.fsh
@@ -6,6 +6,7 @@ Description: "Value set of wHO clinical stage of client based on signs and sympt
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE358"
 
 * HIVConcepts#HIV.D.DE359 "WHO clinical stage 1"
 * HIVConcepts#HIV.D.DE360 "WHO clinical stage 2"

--- a/input/fsh/valuesets/HIV.D.DE370.fsh
+++ b/input/fsh/valuesets/HIV.D.DE370.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why ART was not initiated at diagnosis or with
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE370"
 
 * HIVConcepts#HIV.D.DE371 "Patient self-reported as not ready/willing"
 * HIVConcepts#HIV.D.DE372 "Not completed education, support and preparation for ART"

--- a/input/fsh/valuesets/HIV.D.DE383.fsh
+++ b/input/fsh/valuesets/HIV.D.DE383.fsh
@@ -6,6 +6,7 @@ Description: "Value set of time from HIV diagnosis to when client started ART"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE383"
 
 * HIVConcepts#HIV.D.DE384 "Within 7 days of HIV diagnosis"
 * HIVConcepts#HIV.D.DE385 "Within 30 days of HIV diagnosis"

--- a/input/fsh/valuesets/HIV.D.DE391.fsh
+++ b/input/fsh/valuesets/HIV.D.DE391.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether the viral load is being tested for routine mo
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE391"
 
 * HIVConcepts#HIV.D.DE392 "Routine viral load test"
 * HIVConcepts#HIV.D.DE393 "Targeted viral load monitoring"

--- a/input/fsh/valuesets/HIV.D.DE399.fsh
+++ b/input/fsh/valuesets/HIV.D.DE399.fsh
@@ -6,6 +6,7 @@ Description: "Value set of name of examinations, test and results for any releva
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE399"
 
 * HIVConcepts#HIV.D.DE400 "Haemoglobin (Hb)"
 * HIVConcepts#HIV.D.DE401 "Pregnancy test"

--- a/input/fsh/valuesets/HIV.D.DE418.fsh
+++ b/input/fsh/valuesets/HIV.D.DE418.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why a substitution was made to the antiretrovi
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE418"
 
 * HIVConcepts#HIV.D.DE419 "Toxicity/side effects"
 * HIVConcepts#HIV.D.DE420 "Drug-drug interaction"

--- a/input/fsh/valuesets/HIV.D.DE43.fsh
+++ b/input/fsh/valuesets/HIV.D.DE43.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether the client is ART naive or is restarting ART"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE43"
 
 * HIVConcepts#HIV.D.DE44 "First-time user of ART"
 * HIVConcepts#HIV.D.DE45 "Restarting ART"

--- a/input/fsh/valuesets/HIV.D.DE430.fsh
+++ b/input/fsh/valuesets/HIV.D.DE430.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why a switch to a second- or third-line regime
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE430"
 
 * HIVConcepts#HIV.D.DE431 "Clinical treatment failure"
 * HIVConcepts#HIV.D.DE432 "Immunological failure"

--- a/input/fsh/valuesets/HIV.D.DE444.fsh
+++ b/input/fsh/valuesets/HIV.D.DE444.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE444
+Title: "ART regimen prescribed ValueSet"
+Description: "Value set of iNCLUDE VALUE SETS OF REGIMENS"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE444"

--- a/input/fsh/valuesets/HIV.D.DE446.fsh
+++ b/input/fsh/valuesets/HIV.D.DE446.fsh
@@ -6,6 +6,7 @@ Description: "Value set of clients status of coinfections at the time when ART w
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE446"
 
 * HIVConcepts#HIV.D.DE447 "Hepatitis B"
 * HIVConcepts#HIV.D.DE448 "Hepatitis C"

--- a/input/fsh/valuesets/HIV.D.DE449.fsh
+++ b/input/fsh/valuesets/HIV.D.DE449.fsh
@@ -6,6 +6,7 @@ Description: "Value set of aRT status of women to prevent mother-to-child transm
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE449"
 
 * HIVConcepts#HIV.D.DE450 "Pregnant at ART start"
 * HIVConcepts#HIV.D.DE451 "Postpartum at ART start"

--- a/input/fsh/valuesets/HIV.D.DE457.fsh
+++ b/input/fsh/valuesets/HIV.D.DE457.fsh
@@ -6,4 +6,4 @@ Description: "Value set of name or regimen code of all other medications prescri
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE457"

--- a/input/fsh/valuesets/HIV.D.DE461.fsh
+++ b/input/fsh/valuesets/HIV.D.DE461.fsh
@@ -6,4 +6,4 @@ Description: "Value set of any other medications that were dispensed to client, 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE461"

--- a/input/fsh/valuesets/HIV.D.DE466.fsh
+++ b/input/fsh/valuesets/HIV.D.DE466.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of treatment-limiting toxicity experienced by cl
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE466"
 
 * HIVConcepts#HIV.D.DE467 "Gastrointestinal"
 * HIVConcepts#HIV.D.DE468 "Skin issues"

--- a/input/fsh/valuesets/HIV.D.DE482.fsh
+++ b/input/fsh/valuesets/HIV.D.DE482.fsh
@@ -6,4 +6,4 @@ Description: "Value set of reason(s) why one ore more drugs in client's first-li
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE482"

--- a/input/fsh/valuesets/HIV.D.DE483.fsh
+++ b/input/fsh/valuesets/HIV.D.DE483.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE483
+Title: "New antiretroviral regimen after substitution within first-line regimen ValueSet"
+Description: "Value set of new antiretroviral (ARV) drugs after client changed regimen within the first-line regimen"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE483"

--- a/input/fsh/valuesets/HIV.D.DE485.fsh
+++ b/input/fsh/valuesets/HIV.D.DE485.fsh
@@ -6,4 +6,4 @@ Description: "Value set of new ART regimen after switch to second-line ART regim
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE485"

--- a/input/fsh/valuesets/HIV.D.DE486.fsh
+++ b/input/fsh/valuesets/HIV.D.DE486.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE486
+Title: "Reason for switch to second-line regimen ValueSet"
+Description: "Value set of reason why client was switched from first- to second-line ARV drug regimen (see 'Reason for regimen switch' for levels)"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE486"

--- a/input/fsh/valuesets/HIV.D.DE488.fsh
+++ b/input/fsh/valuesets/HIV.D.DE488.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE488
+Title: "Reason(s) for substitution within second-line regimen ValueSet"
+Description: "Value set of reason(s) why client changed drug regimen (within the second-line)"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE488"

--- a/input/fsh/valuesets/HIV.D.DE489.fsh
+++ b/input/fsh/valuesets/HIV.D.DE489.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE489
+Title: "New regimen(s) after substitution within second-line regimen ValueSet"
+Description: "Value set of new ARV drugs after client changed regimen within the second- line regimen"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE489"

--- a/input/fsh/valuesets/HIV.D.DE491.fsh
+++ b/input/fsh/valuesets/HIV.D.DE491.fsh
@@ -6,4 +6,4 @@ Description: "Value set of new ART regimen after switch to third-line ART regime
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE491"

--- a/input/fsh/valuesets/HIV.D.DE492.fsh
+++ b/input/fsh/valuesets/HIV.D.DE492.fsh
@@ -1,9 +1,9 @@
 ValueSet: HIV.D.DE492
 Title: "Reason for switch to third-line regimen ValueSet"
-Description: "Value set of reason why client was switched from second- to third-line ARV drug regimen (see "Reason for regimen switch" for levels)"
+Description: "Value set of reason why client was switched from second- to third-line ARV drug regimen (see 'Reason for regimen switch' for levels)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE492"

--- a/input/fsh/valuesets/HIV.D.DE494.fsh
+++ b/input/fsh/valuesets/HIV.D.DE494.fsh
@@ -6,4 +6,4 @@ Description: "Value set of reason(s) why client changed drug regimen (within the
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE494"

--- a/input/fsh/valuesets/HIV.D.DE495.fsh
+++ b/input/fsh/valuesets/HIV.D.DE495.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE495
+Title: "New regimen(s) after substitution within third-line regimen ValueSet"
+Description: "Value set of new ARV drugs after client changed regimen within the third-line regimen"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE495"

--- a/input/fsh/valuesets/HIV.D.DE514.fsh
+++ b/input/fsh/valuesets/HIV.D.DE514.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE514
+Title: "HIV status of family member ValueSet"
+Description: "Value set of HIV status of each family member at time of patient's enrolment, including partner (for mothers)"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE514"

--- a/input/fsh/valuesets/HIV.D.DE519.fsh
+++ b/input/fsh/valuesets/HIV.D.DE519.fsh
@@ -6,6 +6,7 @@ Description: "Value set of offer or refer for other support services"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE519"
 
 * HIVConcepts#HIV.D.DE520 "Mental health services"
 * HIVConcepts#HIV.D.DE521 "Psychosocial counselling, support and treatment adherence counselling"

--- a/input/fsh/valuesets/HIV.D.DE52.fsh
+++ b/input/fsh/valuesets/HIV.D.DE52.fsh
@@ -6,4 +6,4 @@ Description: "Value set of name of health facility client was transferred from"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE52"

--- a/input/fsh/valuesets/HIV.D.DE525.fsh
+++ b/input/fsh/valuesets/HIV.D.DE525.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether the visit will be clinical only, ARV drug pic
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE525"
 
 * HIVConcepts#HIV.D.DE526 "Clinical visit"
 * HIVConcepts#HIV.D.DE527 "Antiretroviral drug pick up"

--- a/input/fsh/valuesets/HIV.D.DE532.fsh
+++ b/input/fsh/valuesets/HIV.D.DE532.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why test was not performed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE532"
 
 * HIVConcepts#HIV.D.DE533 "BP cuff (sphygmomanometer) not available"
 * HIVConcepts#HIV.D.DE534 "BP cuff (sphygmomanometer) is broken"

--- a/input/fsh/valuesets/HIV.D.DE537.fsh
+++ b/input/fsh/valuesets/HIV.D.DE537.fsh
@@ -6,6 +6,7 @@ Description: "Value set of list of all of the medications the client is currentl
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE537"
 
 * HIVConcepts#HIV.D.DE538 "No medications"
 * HIVConcepts#HIV.D.DE539 "Don't know of any current medications"

--- a/input/fsh/valuesets/HIV.D.DE55.fsh
+++ b/input/fsh/valuesets/HIV.D.DE55.fsh
@@ -6,4 +6,4 @@ Description: "Value set of facility where the client first enrolled in HIV care"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE55"

--- a/input/fsh/valuesets/HIV.D.DE56.fsh
+++ b/input/fsh/valuesets/HIV.D.DE56.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether or not the client received ARV drugs prior to
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE56"
 
 * HIVConcepts#HIV.D.DE57 "No prior ARVs"
 * HIVConcepts#HIV.D.DE58 "Received ARVs prior without records/documentation"

--- a/input/fsh/valuesets/HIV.D.DE560.fsh
+++ b/input/fsh/valuesets/HIV.D.DE560.fsh
@@ -6,6 +6,7 @@ Description: "Value set of does the client have any allergies?"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE560"
 
 * HIVConcepts#HIV.D.DE561 "No known allergies"
 * HIVConcepts#HIV.D.DE562 "Don't know of any allergies"

--- a/input/fsh/valuesets/HIV.D.DE569.fsh
+++ b/input/fsh/valuesets/HIV.D.DE569.fsh
@@ -6,6 +6,7 @@ Description: "Value set of method the client reports currently using at intake"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE569"
 
 * HIVConcepts#HIV.D.DE570 "Copper-bearing intrauterine device (Cu-IUD)"
 * HIVConcepts#HIV.D.DE571 "Levonorgestrel intrauterine device (LNG-IUD)"

--- a/input/fsh/valuesets/HIV.D.DE593.fsh
+++ b/input/fsh/valuesets/HIV.D.DE593.fsh
@@ -6,6 +6,7 @@ Description: "Value set of current state of the client's taking of the medicatio
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE593"
 
 * HIVConcepts#HIV.D.DE594 "Currently taking"
 * HIVConcepts#HIV.D.DE595 "Completed"

--- a/input/fsh/valuesets/HIV.D.DE603.fsh
+++ b/input/fsh/valuesets/HIV.D.DE603.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the brand or trade name used to refer to the vaccine 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE603"

--- a/input/fsh/valuesets/HIV.D.DE604.fsh
+++ b/input/fsh/valuesets/HIV.D.DE604.fsh
@@ -6,4 +6,4 @@ Description: "Value set of type of vaccine received (such as IPV, OPV)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE604"

--- a/input/fsh/valuesets/HIV.D.DE606.fsh
+++ b/input/fsh/valuesets/HIV.D.DE606.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the service delivery location where the vaccine admin
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE606"

--- a/input/fsh/valuesets/HIV.D.DE610.fsh
+++ b/input/fsh/valuesets/HIV.D.DE610.fsh
@@ -6,6 +6,7 @@ Description: "Value set of vaccine preventable disease being targeted by vaccine
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE610"
 
 * HIVConcepts#HIV.D.DE611 "Hepatitis A"
 * HIVConcepts#HIV.D.DE612 "Hepatitis B"

--- a/input/fsh/valuesets/HIV.D.DE63.fsh
+++ b/input/fsh/valuesets/HIV.D.DE63.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE63
+Title: "Location ARV drugs received prior to enrolment ValueSet"
+Description: "Value set of health facility (or other location) where ARV drugs were received prior to enrolment into HIV care/ART"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE63"

--- a/input/fsh/valuesets/HIV.D.DE636.fsh
+++ b/input/fsh/valuesets/HIV.D.DE636.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason the vaccine dose was not given"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE636"
 
 * HIVConcepts#HIV.D.DE637 "Stock-out"
 * HIVConcepts#HIV.D.DE638 "Client is ill"

--- a/input/fsh/valuesets/HIV.D.DE64.fsh
+++ b/input/fsh/valuesets/HIV.D.DE64.fsh
@@ -1,0 +1,9 @@
+ValueSet: HIV.D.DE64
+Title: "ARV drug regimen received prior to enrolment ValueSet"
+Description: "Value set of aRV drug regimen received prior to enrolment into HIV care/ART"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVDDE64"

--- a/input/fsh/valuesets/HIV.D.DE646.fsh
+++ b/input/fsh/valuesets/HIV.D.DE646.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why the treatment was not given"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE646"
 
 * HIVConcepts#HIV.D.DE647 "Client was referred"
 * HIVConcepts#HIV.D.DE648 "Stock out"

--- a/input/fsh/valuesets/HIV.D.DE65.fsh
+++ b/input/fsh/valuesets/HIV.D.DE65.fsh
@@ -6,6 +6,7 @@ Description: "Value set of does the client have any current chronic health condi
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE65"
 
 * HIVConcepts#HIV.D.DE66 "No chronic or past health conditions"
 * HIVConcepts#HIV.D.DE67 "Don't know"

--- a/input/fsh/valuesets/HIV.D.DE658.fsh
+++ b/input/fsh/valuesets/HIV.D.DE658.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of cervical cancer screening test used in primar
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE658"
 
 * HIVConcepts#HIV.D.DE659 "HPV-DNA"
 * HIVConcepts#HIV.D.DE660 "VIA"

--- a/input/fsh/valuesets/HIV.D.DE664.fsh
+++ b/input/fsh/valuesets/HIV.D.DE664.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hPV-DNA cervical cancer screening test result"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE664"
 
 * HIVConcepts#HIV.D.DE665 "Negative"
 * HIVConcepts#HIV.D.DE666 "Positive"

--- a/input/fsh/valuesets/HIV.D.DE668.fsh
+++ b/input/fsh/valuesets/HIV.D.DE668.fsh
@@ -6,6 +6,7 @@ Description: "Value set of screening test result for VIA"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE668"
 
 * HIVConcepts#HIV.D.DE669 "Negative"
 * HIVConcepts#HIV.D.DE670 "Positive"

--- a/input/fsh/valuesets/HIV.D.DE673.fsh
+++ b/input/fsh/valuesets/HIV.D.DE673.fsh
@@ -6,6 +6,7 @@ Description: "Value set of screening result for cervical cytology"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE673"
 
 * HIVConcepts#HIV.D.DE674 "NILM"
 * HIVConcepts#HIV.D.DE675 "ASCUS"

--- a/input/fsh/valuesets/HIV.D.DE681.fsh
+++ b/input/fsh/valuesets/HIV.D.DE681.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of triage test for cervical cancer"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE681"
 
 * HIVConcepts#HIV.D.DE682 "VIA"
 * HIVConcepts#HIV.D.DE683 "Colposcopy"

--- a/input/fsh/valuesets/HIV.D.DE688.fsh
+++ b/input/fsh/valuesets/HIV.D.DE688.fsh
@@ -6,6 +6,7 @@ Description: "Value set of test result from HPV16/18 test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE688"
 
 * HIVConcepts#HIV.D.DE689 "Positive"
 * HIVConcepts#HIV.D.DE690 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE691.fsh
+++ b/input/fsh/valuesets/HIV.D.DE691.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result of cervical cancer colposcopy"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE691"
 
 * HIVConcepts#HIV.D.DE692 "Normal colposcopic findings"
 * HIVConcepts#HIV.D.DE693 "Abnormal colposcopic findings"

--- a/input/fsh/valuesets/HIV.D.DE697.fsh
+++ b/input/fsh/valuesets/HIV.D.DE697.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result of cervical cancer histopathology"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE697"
 
 * HIVConcepts#HIV.D.DE698 "Normal"
 * HIVConcepts#HIV.D.DE699 "LSIL (inclusive of LSIL-CIN1)"

--- a/input/fsh/valuesets/HIV.D.DE706.fsh
+++ b/input/fsh/valuesets/HIV.D.DE706.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's screening outcome for cervical cancer"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE706"
 
 * HIVConcepts#HIV.D.DE707 "Positive for cervical precancer lesions"
 * HIVConcepts#HIV.D.DE708 "Negative for cervical precancer lesions"

--- a/input/fsh/valuesets/HIV.D.DE709.fsh
+++ b/input/fsh/valuesets/HIV.D.DE709.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of cervical cancer diagnosis"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE709"
 
 * HIVConcepts#HIV.D.DE710 "Cervical precancer lesions"
 * HIVConcepts#HIV.D.DE711 "Invasive cervical cancer"

--- a/input/fsh/valuesets/HIV.D.DE712.fsh
+++ b/input/fsh/valuesets/HIV.D.DE712.fsh
@@ -6,6 +6,7 @@ Description: "Value set of cervical cancer stage at diagnosis of cervical cancer
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE712"
 
 * HIVConcepts#HIV.D.DE713 "Stage 0"
 * HIVConcepts#HIV.D.DE714 "Stage I"

--- a/input/fsh/valuesets/HIV.D.DE719.fsh
+++ b/input/fsh/valuesets/HIV.D.DE719.fsh
@@ -6,6 +6,7 @@ Description: "Value set of treatment method for cervical precancer lesions"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE719"
 
 * HIVConcepts#HIV.D.DE720 "Cryotherapy"
 * HIVConcepts#HIV.D.DE721 "Thermal ablation"

--- a/input/fsh/valuesets/HIV.D.DE731.fsh
+++ b/input/fsh/valuesets/HIV.D.DE731.fsh
@@ -6,6 +6,7 @@ Description: "Value set of invasive cervical cancer treatment method"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE731"
 
 * HIVConcepts#HIV.D.DE732 "Conization"
 * HIVConcepts#HIV.D.DE733 "Trachelectomy"

--- a/input/fsh/valuesets/HIV.D.DE74.fsh
+++ b/input/fsh/valuesets/HIV.D.DE74.fsh
@@ -6,4 +6,4 @@ Description: "Value set of original full, first-line ARV drug regimen patient st
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE74"

--- a/input/fsh/valuesets/HIV.D.DE746.fsh
+++ b/input/fsh/valuesets/HIV.D.DE746.fsh
@@ -6,6 +6,7 @@ Description: "Value set of specific point where testing is happening at a facili
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE746"
 
 * HIVConcepts#HIV.D.DE747 "Provider-initiated tested in a clinic or emergency facility"
 * HIVConcepts#HIV.D.DE748 "Antenatal care clinic"

--- a/input/fsh/valuesets/HIV.D.DE75.fsh
+++ b/input/fsh/valuesets/HIV.D.DE75.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the current ART regimen the client is taking"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE75"

--- a/input/fsh/valuesets/HIV.D.DE753.fsh
+++ b/input/fsh/valuesets/HIV.D.DE753.fsh
@@ -6,6 +6,7 @@ Description: "Value set of other clinical services offered or referrals given to
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE753"
 
 * HIVConcepts#HIV.D.DE754 "Assessment and provision of vaccinations"
 * HIVConcepts#HIV.D.DE755 "Hepatitis B (HBV) and hepatitis C virus (HCV) testing and treatment"

--- a/input/fsh/valuesets/HIV.D.DE764.fsh
+++ b/input/fsh/valuesets/HIV.D.DE764.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of DSD ART model client is enrolled in (country-
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE764"
 
 * HIVConcepts#HIV.D.DE765 "Fast track ART refill"
 * HIVConcepts#HIV.D.DE766 "Facility adherence club"

--- a/input/fsh/valuesets/HIV.D.DE77.fsh
+++ b/input/fsh/valuesets/HIV.D.DE77.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the preferred first-line ART regimen for the client a
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE77"

--- a/input/fsh/valuesets/HIV.D.DE778.fsh
+++ b/input/fsh/valuesets/HIV.D.DE778.fsh
@@ -6,6 +6,7 @@ Description: "Value set of syndrome or STI for which client is diagnosed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE778"
 
 * HIVConcepts#HIV.D.DE779 "Urethral discharge syndrome"
 * HIVConcepts#HIV.D.DE780 "Vaginal discharge syndrome"

--- a/input/fsh/valuesets/HIV.D.DE78.fsh
+++ b/input/fsh/valuesets/HIV.D.DE78.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the alternative first-line ART regimen for the client
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE78"

--- a/input/fsh/valuesets/HIV.D.DE789.fsh
+++ b/input/fsh/valuesets/HIV.D.DE789.fsh
@@ -6,6 +6,7 @@ Description: "Value set of sTI for which the client was tested"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE789"
 
 * HIVConcepts#HIV.D.DE790 "Neisseria gonorrhoeae"
 * HIVConcepts#HIV.D.DE791 "Chlamydia trachomatis"

--- a/input/fsh/valuesets/HIV.D.DE79.fsh
+++ b/input/fsh/valuesets/HIV.D.DE79.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the first-line ART regimen for the client under speci
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE79"

--- a/input/fsh/valuesets/HIV.D.DE80.fsh
+++ b/input/fsh/valuesets/HIV.D.DE80.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the preferred second-line ART regimen for the client 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE80"

--- a/input/fsh/valuesets/HIV.D.DE802.fsh
+++ b/input/fsh/valuesets/HIV.D.DE802.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE802"
 
 * HIVConcepts#HIV.D.DE803 "Positive"
 * HIVConcepts#HIV.D.DE804 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE808.fsh
+++ b/input/fsh/valuesets/HIV.D.DE808.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from Gonorrhoea test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE808"
 
 * HIVConcepts#HIV.D.DE809 "Positive"
 * HIVConcepts#HIV.D.DE810 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE81.fsh
+++ b/input/fsh/valuesets/HIV.D.DE81.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the alternative second-line ART regimen for the clien
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE81"

--- a/input/fsh/valuesets/HIV.D.DE813.fsh
+++ b/input/fsh/valuesets/HIV.D.DE813.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of specimen to be collected"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE813"
 
 * HIVConcepts#HIV.D.DE814 "Blood"
 * HIVConcepts#HIV.D.DE815 "Urine"

--- a/input/fsh/valuesets/HIV.D.DE82.fsh
+++ b/input/fsh/valuesets/HIV.D.DE82.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the optimal regimen for transition to DTG-based regim
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVDDE82"

--- a/input/fsh/valuesets/HIV.D.DE821.fsh
+++ b/input/fsh/valuesets/HIV.D.DE821.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for syphilis (Treponema 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE821"
 
 * HIVConcepts#HIV.D.DE822 "Treponemal"
 * HIVConcepts#HIV.D.DE823 "Non-treponemal"

--- a/input/fsh/valuesets/HIV.D.DE828.fsh
+++ b/input/fsh/valuesets/HIV.D.DE828.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Neisseria gonorrhoea
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE828"
 
 * HIVConcepts#HIV.D.DE829 "NAAT"
 * HIVConcepts#HIV.D.DE830 "POC Test"

--- a/input/fsh/valuesets/HIV.D.DE83.fsh
+++ b/input/fsh/valuesets/HIV.D.DE83.fsh
@@ -6,6 +6,7 @@ Description: "Value set of aRT regimen for treating clients living with HIV, bas
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE83"
 
 * HIVConcepts#HIV.D.DE84 "First-line ART regimen for adults and adolescents"
 * HIVConcepts#HIV.D.DE85 "First-line ART regimen for children"

--- a/input/fsh/valuesets/HIV.D.DE836.fsh
+++ b/input/fsh/valuesets/HIV.D.DE836.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Chlamydia trachomati
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE836"
 
 * HIVConcepts#HIV.D.DE837 "NAAT"
 * HIVConcepts#HIV.D.DE838 "POC Test"

--- a/input/fsh/valuesets/HIV.D.DE845.fsh
+++ b/input/fsh/valuesets/HIV.D.DE845.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Trichomonas vaginali
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE845"
 
 * HIVConcepts#HIV.D.DE846 "NAAT"
 * HIVConcepts#HIV.D.DE847 "POC Test"

--- a/input/fsh/valuesets/HIV.D.DE853.fsh
+++ b/input/fsh/valuesets/HIV.D.DE853.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Herpes simplex virus
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE853"
 
 * HIVConcepts#HIV.D.DE854 "NAAT"
 * HIVConcepts#HIV.D.DE855 "Antibody test"

--- a/input/fsh/valuesets/HIV.D.DE858.fsh
+++ b/input/fsh/valuesets/HIV.D.DE858.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for Mycoplasma genitaliu
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE858"
 
 * HIVConcepts#HIV.D.DE859 "NAAT"
 * HIVConcepts#HIV.D.DE860 "Microscopy"

--- a/input/fsh/valuesets/HIV.D.DE864.fsh
+++ b/input/fsh/valuesets/HIV.D.DE864.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from STI test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE864"
 
 * HIVConcepts#HIV.D.DE865 "Positive"
 * HIVConcepts#HIV.D.DE866 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE869.fsh
+++ b/input/fsh/valuesets/HIV.D.DE869.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of test ued for confirmatory syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE869"
 
 * HIVConcepts#HIV.D.DE870 "Treponemal"
 * HIVConcepts#HIV.D.DE871 "Non-treponemal"

--- a/input/fsh/valuesets/HIV.D.DE877.fsh
+++ b/input/fsh/valuesets/HIV.D.DE877.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from confirmatory STI test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE877"
 
 * HIVConcepts#HIV.D.DE878 "Positive"
 * HIVConcepts#HIV.D.DE879 "Negative"

--- a/input/fsh/valuesets/HIV.D.DE893.fsh
+++ b/input/fsh/valuesets/HIV.D.DE893.fsh
@@ -6,6 +6,7 @@ Description: "Value set of staging of liver disease in client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE893"
 
 * HIVConcepts#HIV.D.DE894 "F0-4, fibrosis staging"
 * HIVConcepts#HIV.D.DE895 "F4 or cirrhosis, presence of cirrhosis"

--- a/input/fsh/valuesets/HIV.D.DE897.fsh
+++ b/input/fsh/valuesets/HIV.D.DE897.fsh
@@ -6,6 +6,7 @@ Description: "Value set of functional status of people with advanced HIV disease
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE897"
 
 * HIVConcepts#HIV.D.DE898 "Working, able to perform usual work inside and outside the home"
 * HIVConcepts#HIV.D.DE899 "Ambulatory, able to perform activity of daily living (ADL), not able to work"

--- a/input/fsh/valuesets/HIV.D.DE90.fsh
+++ b/input/fsh/valuesets/HIV.D.DE90.fsh
@@ -6,6 +6,7 @@ Description: "Value set of list of ART regimens"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE90"
 
 * HIVConcepts#HIV.D.DE91 "ABC + 3TC + ATV/r"
 * HIVConcepts#HIV.D.DE92 "ABC + 3TC + DTG"

--- a/input/fsh/valuesets/HIV.D.DE903.fsh
+++ b/input/fsh/valuesets/HIV.D.DE903.fsh
@@ -6,6 +6,7 @@ Description: "Value set of current or considered medication/drug, for the purpos
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE903"
 
 * HIVConcepts#HIV.D.DE904 "Rifampicin"
 * HIVConcepts#HIV.D.DE905 "Halofantrine"

--- a/input/fsh/valuesets/HIV.D.DE934.fsh
+++ b/input/fsh/valuesets/HIV.D.DE934.fsh
@@ -6,6 +6,7 @@ Description: "Value set of new or recurrent clinical events used to categorize H
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE934"
 
 * HIVConcepts#HIV.D.DE935 "Pulmonary TB"
 * HIVConcepts#HIV.D.DE936 "Lymph node TB"

--- a/input/fsh/valuesets/HIV.D.DE939.fsh
+++ b/input/fsh/valuesets/HIV.D.DE939.fsh
@@ -6,6 +6,7 @@ Description: "Value set of final result of the TB investigation (bacteriological
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE939"
 
 * HIVConcepts#HIV.D.DE940 "Diagnosed TB"
 * HIVConcepts#HIV.D.DE941 "TB excluded"

--- a/input/fsh/valuesets/HIV.D.DE942.fsh
+++ b/input/fsh/valuesets/HIV.D.DE942.fsh
@@ -6,6 +6,7 @@ Description: "Value set of method used to set the TB diagnosis"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE942"
 
 * HIVConcepts#HIV.D.DE943 "Bacteriologically confirmed"
 * HIVConcepts#HIV.D.DE944 "Clinically diagnosed"

--- a/input/fsh/valuesets/HIV.D.DE947.fsh
+++ b/input/fsh/valuesets/HIV.D.DE947.fsh
@@ -6,6 +6,7 @@ Description: "Value set of history of previous TB treatment"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE947"
 
 * HIVConcepts#HIV.D.DE948 "New"
 * HIVConcepts#HIV.D.DE949 "Recurrent"

--- a/input/fsh/valuesets/HIV.D.DE956.fsh
+++ b/input/fsh/valuesets/HIV.D.DE956.fsh
@@ -6,6 +6,7 @@ Description: "Value set of screening algorithm selected for screening activities
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE956"
 
 * HIVConcepts#HIV.D.DE957 "Screening with cough"
 * HIVConcepts#HIV.D.DE958 "Screening with any TB symptom"

--- a/input/fsh/valuesets/HIV.D.DE973.fsh
+++ b/input/fsh/valuesets/HIV.D.DE973.fsh
@@ -6,6 +6,7 @@ Description: "Value set of symptoms that may indicate TB disease in clients livi
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE973"
 
 * HIVConcepts#HIV.D.DE974 "Current cough"
 * HIVConcepts#HIV.D.DE975 "Prolonged cough (>=2w)"

--- a/input/fsh/valuesets/HIV.D.DE986.fsh
+++ b/input/fsh/valuesets/HIV.D.DE986.fsh
@@ -6,6 +6,7 @@ Description: "Value set of record the result of the tuberculosis (TB) screening"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE986"
 
 * HIVConcepts#HIV.D.DE987 "Screen positive for TB"
 * HIVConcepts#HIV.D.DE988 "Screen negative for TB"

--- a/input/fsh/valuesets/HIV.D.DE992.fsh
+++ b/input/fsh/valuesets/HIV.D.DE992.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the type of diagnostic test performed to detect tuber
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVDDE992"
 
 * HIVConcepts#HIV.D.DE993 "LF-LAM"
 * HIVConcepts#HIV.D.DE994 "mWRD test for TB"

--- a/input/fsh/valuesets/HIV.E.DE104.fsh
+++ b/input/fsh/valuesets/HIV.E.DE104.fsh
@@ -6,10 +6,8 @@ Description: "Value set of test result for mother after applying the testing str
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE104"
 
 * HIVConcepts#HIV.E.DE105 "HIV-positive"
 * HIVConcepts#HIV.E.DE106 "HIV-negative"
 * HIVConcepts#HIV.E.DE107 "HIV-inconclusive"
-* HIVConcepts#HIV.E.DE109 "Not exposed"
-* HIVConcepts#HIV.E.DE110 "HIV-exposed"
-* HIVConcepts#HIV.E.DE111 "Unknown HIV exposure"

--- a/input/fsh/valuesets/HIV.E.DE108.fsh
+++ b/input/fsh/valuesets/HIV.E.DE108.fsh
@@ -1,0 +1,13 @@
+ValueSet: HIV.E.DE108
+Title: "Infant or child exposure to HIV ValueSet"
+Description: "Value set of whether the infant or child was determined to have had HIV exposure through mother"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVEDE108"
+
+* HIVConcepts#HIV.E.DE109 "Not exposed"
+* HIVConcepts#HIV.E.DE110 "HIV-exposed"
+* HIVConcepts#HIV.E.DE111 "Unknown HIV exposure"

--- a/input/fsh/valuesets/HIV.E.DE114.fsh
+++ b/input/fsh/valuesets/HIV.E.DE114.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the type of key population that the infant's mother i
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE114"
 
 * HIVConcepts#HIV.E.DE115 "Sex worker"
 * HIVConcepts#HIV.E.DE116 "People who inject drugs"

--- a/input/fsh/valuesets/HIV.E.DE127.fsh
+++ b/input/fsh/valuesets/HIV.E.DE127.fsh
@@ -6,6 +6,7 @@ Description: "Value set of infant feeding practice"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE127"
 
 * HIVConcepts#HIV.E.DE128 "Exclusively breastfeeding"
 * HIVConcepts#HIV.E.DE129 "Replacement feeding"

--- a/input/fsh/valuesets/HIV.E.DE136.fsh
+++ b/input/fsh/valuesets/HIV.E.DE136.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether the amount of iron prescribed is for daily or
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE136"
 
 * HIVConcepts#HIV.E.DE137 "Daily"
 * HIVConcepts#HIV.E.DE138 "Weekly"

--- a/input/fsh/valuesets/HIV.E.DE141.fsh
+++ b/input/fsh/valuesets/HIV.E.DE141.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV status of the infant's mother"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE141"
 
 * HIVConcepts#HIV.E.DE142 "HIV-positive"
 * HIVConcepts#HIV.E.DE143 "HIV-negative"

--- a/input/fsh/valuesets/HIV.E.DE145.fsh
+++ b/input/fsh/valuesets/HIV.E.DE145.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV status of the infant's mother at first ANC vi
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE145"
 
 * HIVConcepts#HIV.E.DE146 "HIV-positive"
 * HIVConcepts#HIV.E.DE147 "HIV-negative"

--- a/input/fsh/valuesets/HIV.E.DE149.fsh
+++ b/input/fsh/valuesets/HIV.E.DE149.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from maternal syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE149"
 
 * HIVConcepts#HIV.E.DE150 "Positive"
 * HIVConcepts#HIV.E.DE151 "Negative"

--- a/input/fsh/valuesets/HIV.E.DE155.fsh
+++ b/input/fsh/valuesets/HIV.E.DE155.fsh
@@ -6,12 +6,9 @@ Description: "Value set of signs the client is at a substantial risk of HIV infe
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE155"
 
 * HIVConcepts#HIV.E.DE156 "No condom use during sex with more than one partner in the past 6 months"
 * HIVConcepts#HIV.E.DE157 "STI in the past 6 months"
 * HIVConcepts#HIV.E.DE158 "A sexual partner in the past 6 months had one or more HIV risk factors"
 * HIVConcepts#HIV.E.DE159 "PrEP requested by client"
-* HIVConcepts#HIV.E.DE169 "Rapid diagnostic test for HIV"
-* HIVConcepts#HIV.E.DE170 "Enzyme immunoassay for HIV"
-* HIVConcepts#HIV.E.DE171 "Nucleic acid test for HIV"
-* HIVConcepts#HIV.E.DE172 "Dual HIV/syphilis rapid diagnostic test"

--- a/input/fsh/valuesets/HIV.E.DE168.fsh
+++ b/input/fsh/valuesets/HIV.E.DE168.fsh
@@ -1,0 +1,14 @@
+ValueSet: HIV.E.DE168
+Title: "HIV test type ValueSet"
+Description: "Value set of type of HIV test"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-shareablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-publishablevalueset"
+* ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
+* ^status = #active
+* ^experimental = true
+* ^name = "HIVEDE168"
+
+* HIVConcepts#HIV.E.DE169 "Rapid diagnostic test for HIV"
+* HIVConcepts#HIV.E.DE170 "Enzyme immunoassay for HIV"
+* HIVConcepts#HIV.E.DE171 "Nucleic acid test for HIV"
+* HIVConcepts#HIV.E.DE172 "Dual HIV/syphilis rapid diagnostic test"

--- a/input/fsh/valuesets/HIV.E.DE17.fsh
+++ b/input/fsh/valuesets/HIV.E.DE17.fsh
@@ -6,6 +6,7 @@ Description: "Value set of whether the woman has had any complications or proble
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE17"
 
 * HIVConcepts#HIV.E.DE18 "No past pregnancy complications"
 * HIVConcepts#HIV.E.DE19 "Does not know of any past pregnancy complications"

--- a/input/fsh/valuesets/HIV.E.DE173.fsh
+++ b/input/fsh/valuesets/HIV.E.DE173.fsh
@@ -6,6 +6,7 @@ Description: "Value set of maternal and child health service visit attended by a
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE173"
 
 * HIVConcepts#HIV.E.DE174 "12-month visit"
 * HIVConcepts#HIV.E.DE175 "24-month visit"

--- a/input/fsh/valuesets/HIV.E.DE180.fsh
+++ b/input/fsh/valuesets/HIV.E.DE180.fsh
@@ -6,4 +6,4 @@ Description: "Value set of early infant diagnosis (EID) sample number"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVEDE180"

--- a/input/fsh/valuesets/HIV.E.DE183.fsh
+++ b/input/fsh/valuesets/HIV.E.DE183.fsh
@@ -6,4 +6,4 @@ Description: "Value set of early infant diagnosis (EID) HIV test number using th
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVEDE183"

--- a/input/fsh/valuesets/HIV.E.DE186.fsh
+++ b/input/fsh/valuesets/HIV.E.DE186.fsh
@@ -6,6 +6,7 @@ Description: "Value set of early infant diagnosis test number 1 test result"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE186"
 
 * HIVConcepts#HIV.E.DE187 "Positive"
 * HIVConcepts#HIV.E.DE188 "Negative"

--- a/input/fsh/valuesets/HIV.E.DE190.fsh
+++ b/input/fsh/valuesets/HIV.E.DE190.fsh
@@ -6,6 +6,7 @@ Description: "Value set of early infant diagnosis test number 2 test result"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE190"
 
 * HIVConcepts#HIV.E.DE191 "Positive"
 * HIVConcepts#HIV.E.DE192 "Negative"

--- a/input/fsh/valuesets/HIV.E.DE194.fsh
+++ b/input/fsh/valuesets/HIV.E.DE194.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the number of the assay (test kit) in the HIV testing
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVEDE194"

--- a/input/fsh/valuesets/HIV.E.DE200.fsh
+++ b/input/fsh/valuesets/HIV.E.DE200.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the first HIV assay in the testing stra
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE200"
 
 * HIVConcepts#HIV.E.DE201 "Reactive"
 * HIVConcepts#HIV.E.DE202 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE204.fsh
+++ b/input/fsh/valuesets/HIV.E.DE204.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the second HIV assay in the testing str
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE204"
 
 * HIVConcepts#HIV.E.DE205 "Reactive"
 * HIVConcepts#HIV.E.DE206 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE208.fsh
+++ b/input/fsh/valuesets/HIV.E.DE208.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the third HIV assay in the testing stra
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE208"
 
 * HIVConcepts#HIV.E.DE209 "Reactive"
 * HIVConcepts#HIV.E.DE210 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE212.fsh
+++ b/input/fsh/valuesets/HIV.E.DE212.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the repeated first HIV assay in the tes
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE212"
 
 * HIVConcepts#HIV.E.DE213 "Reactive"
 * HIVConcepts#HIV.E.DE214 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE216.fsh
+++ b/input/fsh/valuesets/HIV.E.DE216.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the first syphilis assay in the testing
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE216"
 
 * HIVConcepts#HIV.E.DE217 "Reactive"
 * HIVConcepts#HIV.E.DE218 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE220.fsh
+++ b/input/fsh/valuesets/HIV.E.DE220.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the result of the first syphilis assay repeated in th
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE220"
 
 * HIVConcepts#HIV.E.DE221 "Reactive"
 * HIVConcepts#HIV.E.DE222 "Non-reactive"

--- a/input/fsh/valuesets/HIV.E.DE225.fsh
+++ b/input/fsh/valuesets/HIV.E.DE225.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV status reported after applying the HIV testing al
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE225"
 
 * HIVConcepts#HIV.E.DE226 "HIV-positive"
 * HIVConcepts#HIV.E.DE227 "HIV-negative"

--- a/input/fsh/valuesets/HIV.E.DE230.fsh
+++ b/input/fsh/valuesets/HIV.E.DE230.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV-exposed infant final status at 18 months or 3 mon
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE230"
 
 * HIVConcepts#HIV.E.DE231 "HIV-positive"
 * HIVConcepts#HIV.E.DE232 "HIV-negative and no longer breastfeeding"

--- a/input/fsh/valuesets/HIV.E.DE234.fsh
+++ b/input/fsh/valuesets/HIV.E.DE234.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the outcome for the infant does not have a final outc
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE234"
 
 * HIVConcepts#HIV.E.DE235 "Lost to follow-up"
 * HIVConcepts#HIV.E.DE236 "Transferred out"

--- a/input/fsh/valuesets/HIV.E.DE240.fsh
+++ b/input/fsh/valuesets/HIV.E.DE240.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the infant's cause of death"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVEDE240"

--- a/input/fsh/valuesets/HIV.E.DE246.fsh
+++ b/input/fsh/valuesets/HIV.E.DE246.fsh
@@ -6,6 +6,7 @@ Description: "Value set of mother's blood type and blood Rh factor"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE246"
 
 * HIVConcepts#HIV.E.DE247 "A+"
 * HIVConcepts#HIV.E.DE248 "A-"

--- a/input/fsh/valuesets/HIV.E.DE255.fsh
+++ b/input/fsh/valuesets/HIV.E.DE255.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result of urine culture (or urine Gram-staining if no
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE255"
 
 * HIVConcepts#HIV.E.DE256 "Positive"
 * HIVConcepts#HIV.E.DE257 "Negative"

--- a/input/fsh/valuesets/HIV.E.DE259.fsh
+++ b/input/fsh/valuesets/HIV.E.DE259.fsh
@@ -6,6 +6,7 @@ Description: "Value set of results of urine protein test of mother during ANC vi
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE259"
 
 * HIVConcepts#HIV.E.DE260 "0"
 * HIVConcepts#HIV.E.DE261 "+"

--- a/input/fsh/valuesets/HIV.E.DE264.fsh
+++ b/input/fsh/valuesets/HIV.E.DE264.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of hypertensive disorder of the mother"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE264"
 
 * HIVConcepts#HIV.E.DE265 "Chronic hypertension"
 * HIVConcepts#HIV.E.DE266 "Essential"

--- a/input/fsh/valuesets/HIV.E.DE41.fsh
+++ b/input/fsh/valuesets/HIV.E.DE41.fsh
@@ -6,6 +6,7 @@ Description: "Value set of when the pregnant woman or mother initiated ART, for 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE41"
 
 * HIVConcepts#HIV.E.DE42 "Already on ART at first antenatal care visit"
 * HIVConcepts#HIV.E.DE43 "Newly on ART during pregnancy"

--- a/input/fsh/valuesets/HIV.E.DE47.fsh
+++ b/input/fsh/valuesets/HIV.E.DE47.fsh
@@ -6,6 +6,7 @@ Description: "Value set of outcome of current pregnancy"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE47"
 
 * HIVConcepts#HIV.E.DE48 "Live birth"
 * HIVConcepts#HIV.E.DE49 "Early fetal loss/miscarriage"

--- a/input/fsh/valuesets/HIV.E.DE52.fsh
+++ b/input/fsh/valuesets/HIV.E.DE52.fsh
@@ -6,6 +6,7 @@ Description: "Value set of mode of delivery for current pregnancy"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE52"
 
 * HIVConcepts#HIV.E.DE53 "Spontaneous vaginal delivery"
 * HIVConcepts#HIV.E.DE54 "Assisted vaginal delivery"

--- a/input/fsh/valuesets/HIV.E.DE6.fsh
+++ b/input/fsh/valuesets/HIV.E.DE6.fsh
@@ -6,6 +6,7 @@ Description: "Value set of gestational age can be calculated multiple ways. This
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE6"
 
 * HIVConcepts#HIV.E.DE7 "Last menstrual period (LMP)"
 * HIVConcepts#HIV.E.DE8 "Ultrasound"

--- a/input/fsh/valuesets/HIV.E.DE62.fsh
+++ b/input/fsh/valuesets/HIV.E.DE62.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the woman gave birth when the gestational age is less
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE62"
 
 * HIVConcepts#HIV.E.DE63 "Not preterm"
 * HIVConcepts#HIV.E.DE64 "Preterm (<37 weeks gestation)"

--- a/input/fsh/valuesets/HIV.E.DE67.fsh
+++ b/input/fsh/valuesets/HIV.E.DE67.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the type of place where the woman delivered"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE67"
 
 * HIVConcepts#HIV.E.DE68 "Health facility"
 * HIVConcepts#HIV.E.DE69 "Home"

--- a/input/fsh/valuesets/HIV.E.DE75.fsh
+++ b/input/fsh/valuesets/HIV.E.DE75.fsh
@@ -6,4 +6,4 @@ Description: "Value set of the woman's cause of death"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVEDE75"

--- a/input/fsh/valuesets/HIV.E.DE91.fsh
+++ b/input/fsh/valuesets/HIV.E.DE91.fsh
@@ -6,6 +6,7 @@ Description: "Value set of gender of the infant"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVEDE91"
 
 * HIVConcepts#HIV.E.DE92 "Female"
 * HIVConcepts#HIV.E.DE93 "Male"

--- a/input/fsh/valuesets/HIV.G.DE13.fsh
+++ b/input/fsh/valuesets/HIV.G.DE13.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the type of specimen to be used to test viral load"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE13"
 
 * HIVConcepts#HIV.G.DE14 "Liquid plasma specimen for viral load testing"
 * HIVConcepts#HIV.G.DE15 "Dried blood spot specimen"

--- a/input/fsh/valuesets/HIV.G.DE18.fsh
+++ b/input/fsh/valuesets/HIV.G.DE18.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis B virus test result (HBsAg)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE18"
 
 * HIVConcepts#HIV.G.DE19 "Positive"
 * HIVConcepts#HIV.G.DE20 "Negative"

--- a/input/fsh/valuesets/HIV.G.DE22.fsh
+++ b/input/fsh/valuesets/HIV.G.DE22.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why a hepatitis B test was not done"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE22"
 
 * HIVConcepts#HIV.G.DE23 "Test delayed to next contact or referred"
 * HIVConcepts#HIV.G.DE24 "Stock-out or expired"

--- a/input/fsh/valuesets/HIV.G.DE29.fsh
+++ b/input/fsh/valuesets/HIV.G.DE29.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's hepatitis B diagnosis"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE29"
 
 * HIVConcepts#HIV.G.DE30 "Hepatitis B positive"
 * HIVConcepts#HIV.G.DE31 "Hepatitis B negative"

--- a/input/fsh/valuesets/HIV.G.DE35.fsh
+++ b/input/fsh/valuesets/HIV.G.DE35.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why a hepatitis C test was not done"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE35"
 
 * HIVConcepts#HIV.G.DE36 "Test delayed to next contact or referred"
 * HIVConcepts#HIV.G.DE37 "Stock-out or expired"

--- a/input/fsh/valuesets/HIV.G.DE43.fsh
+++ b/input/fsh/valuesets/HIV.G.DE43.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis C virus test result (HCV antibody, HCV RNA 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE43"
 
 * HIVConcepts#HIV.G.DE44 "Positive"
 * HIVConcepts#HIV.G.DE45 "Negative"

--- a/input/fsh/valuesets/HIV.G.DE48.fsh
+++ b/input/fsh/valuesets/HIV.G.DE48.fsh
@@ -6,6 +6,7 @@ Description: "Value set of hepatitis C viral load test result (qualitative)"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE48"
 
 * HIVConcepts#HIV.G.DE49 "Detected"
 * HIVConcepts#HIV.G.DE50 "Not detected"

--- a/input/fsh/valuesets/HIV.G.DE51.fsh
+++ b/input/fsh/valuesets/HIV.G.DE51.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's hepatitis C diagnosis"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE51"
 
 * HIVConcepts#HIV.G.DE52 "Hepatitis C positive"
 * HIVConcepts#HIV.G.DE53 "Hepatitis C negative"

--- a/input/fsh/valuesets/HIV.G.DE55.fsh
+++ b/input/fsh/valuesets/HIV.G.DE55.fsh
@@ -6,6 +6,7 @@ Description: "Value set of type of diagnostic test used for syphilis (treponema 
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE55"
 
 * HIVConcepts#HIV.G.DE56 "Treponemal"
 * HIVConcepts#HIV.G.DE57 "Non-treponemal"

--- a/input/fsh/valuesets/HIV.G.DE62.fsh
+++ b/input/fsh/valuesets/HIV.G.DE62.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why a syphilis test was not done"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE62"
 
 * HIVConcepts#HIV.G.DE63 "Test delayed to next contact or referred"
 * HIVConcepts#HIV.G.DE64 "Stock-out or expired"

--- a/input/fsh/valuesets/HIV.G.DE70.fsh
+++ b/input/fsh/valuesets/HIV.G.DE70.fsh
@@ -6,6 +6,7 @@ Description: "Value set of result from syphilis test"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE70"
 
 * HIVConcepts#HIV.G.DE71 "Positive"
 * HIVConcepts#HIV.G.DE72 "Negative"

--- a/input/fsh/valuesets/HIV.G.DE74.fsh
+++ b/input/fsh/valuesets/HIV.G.DE74.fsh
@@ -6,6 +6,7 @@ Description: "Value set of client's syphilis diagnosis"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVGDE74"
 
 * HIVConcepts#HIV.G.DE75 "Syphilis positive"
 * HIVConcepts#HIV.G.DE76 "Syphilis negative"

--- a/input/fsh/valuesets/HIV.H.DE1.fsh
+++ b/input/fsh/valuesets/HIV.H.DE1.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the reason why the client is being followed up"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE1"
 
 * HIVConcepts#HIV.H.DE2 "Missed care visit"
 * HIVConcepts#HIV.H.DE3 "Missed medication pickup"

--- a/input/fsh/valuesets/HIV.H.DE13.fsh
+++ b/input/fsh/valuesets/HIV.H.DE13.fsh
@@ -6,6 +6,7 @@ Description: "Value set of method used to try to reach out to the client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE13"
 
 * HIVConcepts#HIV.H.DE14 "Home visit"
 * HIVConcepts#HIV.H.DE15 "Text message"

--- a/input/fsh/valuesets/HIV.H.DE17.fsh
+++ b/input/fsh/valuesets/HIV.H.DE17.fsh
@@ -6,6 +6,7 @@ Description: "Value set of source of information about the client"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE17"
 
 * HIVConcepts#HIV.H.DE18 "Client"
 * HIVConcepts#HIV.H.DE19 "Informed by treatment provider"

--- a/input/fsh/valuesets/HIV.H.DE23.fsh
+++ b/input/fsh/valuesets/HIV.H.DE23.fsh
@@ -6,6 +6,7 @@ Description: "Value set of detailed outcome from the attempt to locate the clien
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE23"
 
 * HIVConcepts#HIV.H.DE24 "Returning to clinic"
 * HIVConcepts#HIV.H.DE25 "Self-transferred out"

--- a/input/fsh/valuesets/HIV.H.DE34.fsh
+++ b/input/fsh/valuesets/HIV.H.DE34.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV status of the partner or contact given by the ind
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE34"
 
 * HIVConcepts#HIV.H.DE35 "Already knew positive"
 * HIVConcepts#HIV.H.DE36 "Newly diagnosed"

--- a/input/fsh/valuesets/HIV.H.DE41.fsh
+++ b/input/fsh/valuesets/HIV.H.DE41.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the outcome for the client which is used for reportin
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE41"
 
 * HIVConcepts#HIV.H.DE42 "Lost to follow-up"
 * HIVConcepts#HIV.H.DE43 "Transferred out"

--- a/input/fsh/valuesets/HIV.H.DE50.fsh
+++ b/input/fsh/valuesets/HIV.H.DE50.fsh
@@ -6,4 +6,4 @@ Description: "Value set of name of health facility client was transferred to"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
-
+* ^name = "HIVHDE50"

--- a/input/fsh/valuesets/HIV.H.DE53.fsh
+++ b/input/fsh/valuesets/HIV.H.DE53.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why client is not adherent"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE53"
 
 * HIVConcepts#HIV.H.DE54 "Forgot"
 * HIVConcepts#HIV.H.DE55 "Toxicity/side effects"

--- a/input/fsh/valuesets/HIV.H.DE74.fsh
+++ b/input/fsh/valuesets/HIV.H.DE74.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why client intentionally stopped ART"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVHDE74"
 
 * HIVConcepts#HIV.H.DE75 "Toxicity/side effects"
 * HIVConcepts#HIV.H.DE76 "Severe illness, hospitalization"

--- a/input/fsh/valuesets/HIV.I.DE2.fsh
+++ b/input/fsh/valuesets/HIV.I.DE2.fsh
@@ -6,6 +6,7 @@ Description: "Value set of reason why the client is being referred. If diagnosed
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVIDE2"
 
 * HIVConcepts#HIV.I.DE3 "Hospital"
 * HIVConcepts#HIV.I.DE4 "Referral for screening including diagnostics and lab testing"

--- a/input/fsh/valuesets/HIV.PRV.DE11.fsh
+++ b/input/fsh/valuesets/HIV.PRV.DE11.fsh
@@ -6,6 +6,7 @@ Description: "Value set of the HIV status of the client's contact"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVPRVDE11"
 
 * HIVConcepts#HIV.PRV.DE12 "HIV-positive"
 * HIVConcepts#HIV.PRV.DE13 "HIV-negative"

--- a/input/fsh/valuesets/HIV.PRV.DE2.fsh
+++ b/input/fsh/valuesets/HIV.PRV.DE2.fsh
@@ -6,6 +6,7 @@ Description: "Value set of HIV prevention intervention that client accessed"
 * ^meta.profile[+] = "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-computablevalueset"
 * ^status = #active
 * ^experimental = true
+* ^name = "HIVPRVDE2"
 
 * HIVConcepts#HIV.PRV.DE3 "PrEP service"
 * HIVConcepts#HIV.PRV.DE4 "OAMT"


### PR DESCRIPTION
This currently produces a single error on my machine:

> Sushi: error Cannot define element dateViralLoadTestResultsReceivedByClient on HIVDCareTreatment because it has already been defined
Sushi:   File: who-smart-guidelines/hiv-dak/smart-hiv/input/fsh/models/HIVDCareTreatment.fsh
Sushi:   Line: 361 

This arises from the L2 artifacts defining two data elements (HIV.D.DE192 and HIV.D.DE416) with exactly the same label: "Date viral load test results received by client"